### PR TITLE
Highlight tokens causing parse error if metadata available

### DIFF
--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -544,7 +544,15 @@ function displayError(response, statusWithText = undefined) {
     if (response.query.length >= 1) { response.query = response.query[0]; }
     else { response.query = "response.query is an empty array"; }
   }
-  disp += "Your query was: " + "<br><pre>" + htmlEscape(response.query) + "</pre>";
+  let queryToDisplay = response.query;
+  if("metadata" in response && "startIndex" in response.metadata && "stopIndex" in response.metadata) {
+    let start = response.metadata.startIndex;
+    let stop = response.metadata.stopIndex;
+    queryToDisplay = htmlEscape(queryToDisplay.substr(0,start)) + "<b><u style='color: red'>" + htmlEscape(queryToDisplay.substr(start, stop)) + "</u></b>" + htmlEscape(queryToDisplay.substr(stop+1));
+  } else {
+      queryToDisplay = htmlEscape(queryToDisplay);
+  }
+  disp += "Your query was: " + "<br><pre>" + queryToDisplay + "</pre>";
   // disp += "Your query was: " + "<br><pre>" + htmlEscape(result.query) + "</pre>";
   // if (result['exception']) {
   //   disp += "<small><strong>Exception: </strong><em>";

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -545,20 +545,20 @@ function displayError(response, statusWithText = undefined) {
     else { response.query = "response.query is an empty array"; }
   }
   let queryToDisplay = response.query;
-  if("metadata" in response && "startIndex" in response.metadata && "stopIndex" in response.metadata) {
+  // If the error response contains metadata about position of parse error,
+  // highlight that part.
+  if ("metadata" in response && "startIndex" in response.metadata
+                             && "stopIndex" in response.metadata) {
     let start = response.metadata.startIndex;
     let stop = response.metadata.stopIndex;
-    queryToDisplay = htmlEscape(queryToDisplay.substring(0,start)) + "<b><u style='color: red'>" + htmlEscape(queryToDisplay.substring(start, stop+1)) + "</u></b>" + htmlEscape(queryToDisplay.substring(stop+1));
+    queryToDisplay = htmlEscape(queryToDisplay.substring(0, start))
+                       + "<b><u style=\"color: red\">"
+                       + htmlEscape(queryToDisplay.substring(start, stop + 1))
+                       + "</u></b>" + htmlEscape(queryToDisplay.substring(stop + 1));
   } else {
       queryToDisplay = htmlEscape(queryToDisplay);
   }
   disp += "Your query was: " + "<br><pre>" + queryToDisplay + "</pre>";
-  // disp += "Your query was: " + "<br><pre>" + htmlEscape(result.query) + "</pre>";
-  // if (result['exception']) {
-  //   disp += "<small><strong>Exception: </strong><em>";
-  //   disp += htmlEscape(result['exception']);
-  //   disp += "</em></small>";
-  // }
   $('#errorReason').html(disp);
   $('#errorBlock').show();
   $('#answerBlock, #infoBlock').hide();

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -548,7 +548,7 @@ function displayError(response, statusWithText = undefined) {
   if("metadata" in response && "startIndex" in response.metadata && "stopIndex" in response.metadata) {
     let start = response.metadata.startIndex;
     let stop = response.metadata.stopIndex;
-    queryToDisplay = htmlEscape(queryToDisplay.substr(0,start)) + "<b><u style='color: red'>" + htmlEscape(queryToDisplay.substr(start, stop)) + "</u></b>" + htmlEscape(queryToDisplay.substr(stop+1));
+    queryToDisplay = htmlEscape(queryToDisplay.substring(0,start)) + "<b><u style='color: red'>" + htmlEscape(queryToDisplay.substring(start, stop+1)) + "</u></b>" + htmlEscape(queryToDisplay.substring(stop+1));
   } else {
       queryToDisplay = htmlEscape(queryToDisplay);
   }


### PR DESCRIPTION
With ad-freiburg/qlever#790 qlever will be returning metadata about parse errors. When a parsing error happens the exact location that caused it will also be returned. This PR makes use of that information in the frontend to highlight the location in the echoed query. The highlighting is still basic but it works. 

Example:
![image](https://user-images.githubusercontent.com/14220769/190688105-9ed6f7f9-7ef1-4199-a03b-e351b5b81a46.png)
