### PR TITLE
Make "Automatically add names to result" checkbox work for `api/vvz`

### DIFF
--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -223,6 +223,11 @@ async function enhanceQueryByNameTriples(query) {
     name_template="%ENTITY% rdfs:label %NAME%";
     predicate_exists_regex="rdfs:label";
     new_var_suffix="_label";
+  } else if (BASEURL.match(/api\/vvz$/)) {
+    prefix_definitions=["PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>"];
+    name_template="%ENTITY% rdfs:label %NAME%";
+    predicate_exists_regex="rdfs:label";
+    new_var_suffix="_label";
   } else {
     return query;
   }


### PR DESCRIPTION
This PR enables the `Automatically add names to result` option for a knowledge graph that contains the VVZ (Vorlesungsverzeichnis) data. This has to be a PR because this cannot be configured in the Django. It is possible to make the knowledge graph available via qlever.cs.uni-freiburg.de once it is finished.