### PR TITLE
Examples command

### DIFF
--- a/backend/management/commands/examples.py
+++ b/backend/management/commands/examples.py
@@ -1,0 +1,77 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db.models import TextChoices
+from backend.models import Backend
+from backend.models import Link
+from backend.models import Example
+from pprint import pprint
+import requests
+import sys
+import re
+
+# Command to get the example queries from the particular backend, with one line
+# per query, in the format:
+# 
+# name of query<TAB>SPARQL query in one line without newlines
+#
+# TODO: Provide option to return result as JSON.
+class Command(BaseCommand):
+    help = "Usage: python manage.py examples <argument string>"
+
+    # Copied from warmup.py, is this really needed?
+    def __init__(self, *args, **kwargs):
+        super().__init__( *args, **kwargs)
+
+    # Custom log function.
+    def log(self, msg=""):
+        print(msg)
+
+    # Command line arguments.
+    def add_arguments(self, parser):
+        parser.add_argument("slug", nargs=1, help="Slug of the backend")
+
+    # This defines the actual behavior.
+    def handle(self, *args, returnLog=False, **options):
+        try:
+            slug = options["slug"][0]
+        except Exception as e:
+            self.log(f"Error parsing command line arguments: {e}")
+            self.log()
+            self.print_help("manage.py", "examples")
+            return
+        try:
+            backend = Backend.objects.filter(slug=slug).get()
+        except Exception as e:
+            self.log(f"Error finding config with slug \"{slug}\": {e}")
+            return
+        # self.log()
+        # self.log(f"ID of backend \"{slug}\" is: {backend.pk}")
+        # self.log()
+        # self.log(f"Keys of Example table: {Example._meta.fields}")
+        result = []
+        for example in Example.objects.all():
+            if example.backend.pk == backend.pk:
+                query_name = example.name
+                query_string = self.normalize_query(example.query)
+                result.append(f"{query_name}\t{query_string}")
+        self.log(f"Returning {len(result)} example queries for backend \"{slug}\"")
+        return "\n".join(result) + "\n"
+
+    # Helper function for normalizing a query (translated from
+    # static/js/helper.js).
+    def normalize_query(self, query):
+        # Replace # in IRIs by %23.
+        query = re.sub(r'(<[^>]+)#', r'\1%23', query)
+        # Remove comments.
+        query = re.sub(r'#.*\n', ' ', query, flags=re.MULTILINE)
+        # Re-replace %23 in IRIs by #.
+        query = re.sub(r'(<[^>]+)%23', r'\1#', query)
+        # Replace all sequences of whitespace by a single space.
+        query = re.sub(r'\s+', ' ', query)
+        # Remove . before }.
+        query = re.sub(r'\s*\.\s*}', ' }', query)
+        # Remove any trailing whitespace.
+        query = query.strip()
+
+        return query
+
+

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -286,13 +286,13 @@ li.CodeMirror-hint-active {
 
 #result-tree .node > p { margin: 0; white-space: nowrap; }
 #result-tree .node-name { font-weight: bold; }
+/* #result-tree .node-status { font-size: 80%; color: blue; } */
 #result-tree .node-status:before { content: "Status: " }
-/* #result-tree .node-status { font-size: 90%; } */
 #result-tree .node-status.failed { font-weight: bold; color: red; }
 #result-tree .node-status.child-failed { color: red; }
 #result-tree .node-status.not-started { color: blue; }
 #result-tree .node-status.optimized-out { color: blue; }
-#result-tree .node-status.complete-during-query-planning { color: blue; }
+#result-tree .node-status.lazily-materialized { color: blue; }
 #result-tree .node-cols:before { content: "Cols: "; }
 #result-tree .node-size:before { content: "Size: "; }
 #result-tree .node-size { display: inline; }
@@ -301,6 +301,8 @@ li.CodeMirror-hint-active {
 #result-tree .node-time { display: inline; }
 #result-tree .node-cost-estimate { display: inline; padding-left: 1em; }
 #result-tree .node-time:after { content: "ms"; }
+#result-tree .node-details { display: none; color: blue; }
+#result-tree .node-details:before { content: "Details: " }
 #result-tree div.cached-not-pinned .node-time:after { content: "ms [cached]"; }
 #result-tree div.cached-pinned .node-time:after { content: "ms [cached, pinned]"; }
 #result-tree div.ancestor-cached .node-time:after { content: "ms [ancestor cached]"; }

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -93,7 +93,7 @@ function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cac
     // console.log("-> REWRITTEN TO:", text["name"])
 
     text["status"] = tree_node["status"];
-    if (text["status"] == "completed") { delete text["status"]; }
+    if (text["status"] == "fully materialized") { delete text["status"]; }
     text["cols"] = tree_node["column_names"].join(", ")
     .replace(/qlc_/g, "").replace(/_qlever_internal_variable_query_planner/g, "")
     .replace(/\?[A-Z_]*/g, function (match) { return match.toLowerCase(); });
@@ -111,6 +111,10 @@ function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cac
       : formatInteger(tree_node["original_operation_time"]);
     text["cost-estimate"] = "[~ " + formatInteger(tree_node["estimated_operation_cost"]) + "]"
     text["total"] = text["time"];
+    if (tree_node["details"]) {
+      text["details"] = JSON.stringify(tree_node["details"]);
+      console.log("details:", text["details"]);
+    }
 
     // Delete all other keys except "children" (we only needed them here to
     // create a proper "text" element) and the "text" element.

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -657,6 +657,14 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       nodeStructure: runtime_info["query_execution_tree"]
     }
     var treant_chart = new Treant(treant_tree);
+
+    // For each node, on mouseover show the details.
+    $("div.node").hover(function () {
+      $(this).children(".node-details").show();
+    }, function () {
+      $(this).children(".node-details").hide();
+    });
+
     $("p.node-time").
     filter(function () { return $(this).html().replace(/,/g, "") >= high_query_time_ms }).
     parent().addClass("high");
@@ -669,12 +677,12 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
                             .parent().addClass("cached-pinned").addClass("cached");
     $("p.node-cache-status").filter(function () { return $(this).html() === "ancestor_cached" })
                             .parent().addClass("ancestor-cached").addClass("cached");
-    $("p.node-status").filter(function() { return $(this).text() === "completed"}).addClass("completed");
+    $("p.node-status").filter(function() { return $(this).text() === "fully materialized"}).addClass("fully-materialized");
+    $("p.node-status").filter(function() { return $(this).text() === "lazily materialized"}).addClass("lazily-materialized");
     $("p.node-status").filter(function() { return $(this).text() === "failed"}).addClass("failed");
     $("p.node-status").filter(function() { return $(this).text() === "failed because child failed"}).addClass("child-failed");
     $("p.node-status").filter(function() { return $(this).text() === "not started"}).addClass("not-started");
     $("p.node-status").filter(function() { return $(this).text() === "optimized out"}).addClass("optimized-out");
-    $("p.node-status").filter(function() { return $(this).text() === "completed during query planning"}).addClass("completed-during-query-planning");
     
     if ($('#logRequests').is(':checked')) {
       select = "";

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -9,4 +9,5 @@ urlpatterns = [
         name='index'),
     re_path(r'^api/share$', views.shareLink, name='shareLink'),
     re_path(r'^api/warmup/(?P<backend>[^/]+)/(?P<target>[a-zA-Z0-9_-]+)$', views.warmup, name='warmup'),
+    re_path(r'^api/examples/(?P<backend>[^/]+)$', views.examples, name='examples'),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -8,6 +8,7 @@ from django.shortcuts import render
 
 from .models import *
 from backend.management.commands.warmup import Command as WarmupCommand
+from backend.management.commands.examples import Command as ExamplesCommand
 
 import json
 import urllib
@@ -122,6 +123,7 @@ def shareLink(request):
         return redirect('/')
 
 
+# Handle "warmup" request.
 def warmup(request, backend, target):
     token = request.GET.get("token")
     backends = Backend.objects.filter(slug=backend)
@@ -143,12 +145,24 @@ def warmup(request, backend, target):
     except Exception as e:
         return JsonResponse({"status":"error", "message": str(e)})
     return JsonResponse({"status":"ok", "log": log})
+
+# Handle "examples" request, for example:
 #
+# With the URL https://qlever.cs.uni-freiburg.de/api/examples/wikidata
+#
+# this function is called with backend = "wikidata".
+def examples(request, backend):
+    print_to_log(f"Call of \"examples\" in views.py with backend = \"{backend}\"")
+    command = ExamplesCommand()
+    try:
+        tsv = command.handle(returnLog=True, slug=[backend])
+    except Exception as e:
+        return HttpResponse("Error: " + str(e), status=500)
+    return HttpResponse(tsv, content_type="text/tab-separated-values")
+
+
 # Helpers
-#
-
-
-def log(msg, output=print):
+def print_to_log(msg, output=print):
     """
         Helper to log things that happen during the process
     """


### PR DESCRIPTION
There is now a new command and view that can be used to retrieve all
example queries for a given backend as TSV. Here is an example call:

`docker exec -it qlever-ui bash -c "python manage.py examples wikidata"`

To obtain the same result via an API call (no special permissions
required):

`curl -s https://qlever.cs.uni-freiburg.de/api/examples/wikidata`