### PR TITLE
"Analysis" tree now shows live updates

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -279,7 +279,6 @@ li.CodeMirror-hint-active {
   background-color: #FEFEFE;
   border: 1px solid #000;
   min-width: 25em;
-  /* max-width: 40em; */
   font-size: 80%;
   color: black;
 }
@@ -288,9 +287,6 @@ li.CodeMirror-hint-active {
 #result-tree .node-name { font-weight: bold; }
 #result-tree .node-status { font-size: 90%; color: #000099; }
 #result-tree .node.not-started { color: #999; }
-/* #result-tree .node-status:before { content: "Status: " } */
-/* #result-tree p.node-status { display: none; } */
-/* #result-tree p.not-started { display: none; } */
 #result-tree p.fully-materialized { display: none; }
 #result-tree p.lazily-materialized { display: none; }
 #result-tree .node-status.failed { font-weight: bold; color: red; }

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -279,15 +279,20 @@ li.CodeMirror-hint-active {
   background-color: #FEFEFE;
   border: 1px solid #000;
   min-width: 25em;
-  max-width: 40em;
+  /* max-width: 40em; */
   font-size: 80%;
   color: black;
 }
 
 #result-tree .node > p { margin: 0; white-space: nowrap; }
 #result-tree .node-name { font-weight: bold; }
-/* #result-tree .node-status { font-size: 80%; color: blue; } */
-#result-tree .node-status:before { content: "Status: " }
+#result-tree .node-status { font-size: 90%; color: #000099; }
+#result-tree .node.not-started { color: #999; }
+/* #result-tree .node-status:before { content: "Status: " } */
+/* #result-tree p.node-status { display: none; } */
+/* #result-tree p.not-started { display: none; } */
+#result-tree p.fully-materialized { display: none; }
+#result-tree p.lazily-materialized { display: none; }
 #result-tree .node-status.failed { font-weight: bold; color: red; }
 #result-tree .node-status.child-failed { color: red; }
 #result-tree .node-status.not-started { color: blue; }
@@ -300,6 +305,7 @@ li.CodeMirror-hint-active {
 #result-tree .node-time:before { content: "\ATime: "; white-space: pre; }
 #result-tree .node-time { display: inline; }
 #result-tree .node-cost-estimate { display: inline; padding-left: 1em; }
+#result-tree .node-status { display: inline; padding-left: 1em; }
 #result-tree .node-time:after { content: "ms"; }
 #result-tree .node-details { display: none; color: blue; }
 #result-tree .node-details:before { content: "Details: " }

--- a/backend/static/js/codemirror/modes/sparql/sparql-hint.js
+++ b/backend/static/js/codemirror/modes/sparql/sparql-hint.js
@@ -790,19 +790,10 @@ function getQleverSuggestions(sparqlQuery, prefixesRelation, appendix, nameList,
         data = await response.json();
       }
 
-      if ($('#logRequests').is(':checked')) {
-        runtime_log[runtime_log.length] = data.runtimeInformation;
-        query_log[query_log.length] = data.query;
-        if (runtime_log.length - 10 >= 0) {
-          runtime_log[runtime_log.length - 10] = null;
-          query_log[query_log.length - 10] = null;
-        }
-      }
-
       
       if (data.res) {
         log("Got suggestions from QLever.", 'other');
-        log("Query took " + data.time.total + " and found " + data.resultsize + " lines\nRuntime info is saved as [" + (query_log.length) + "]", 'requests');
+        log("Query took " + data.time.total + " and found " + data.resultsize + " lines", 'requests');
         var entityIndex = data.selected.indexOf(SUGGESTIONENTITYVARIABLE);
         var suggested = {};
         var ogc_contains_added = false;

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -101,8 +101,6 @@ function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cac
     .replace(/AVAILABLE /, "").replace(/a all/, "all");
     // console.log("-> REWRITTEN TO:", text["name"])
 
-    text["status"] = tree_node["status"];
-    if (text["status"] == "fully materialized") { delete text["status"]; }
     text["cols"] = tree_node["column_names"].join(", ")
     .replace(/qlc_/g, "").replace(/_qlever_internal_variable_query_planner/g, "")
     .replace(/\?[A-Z_]*/g, function (match) { return match.toLowerCase(); });
@@ -119,6 +117,9 @@ function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cac
       ? formatInteger(tree_node["operation_time"])
       : formatInteger(tree_node["original_operation_time"]);
     text["cost-estimate"] = "[~ " + formatInteger(tree_node["estimated_operation_cost"]) + "]"
+    text["status"] = tree_node["status"];
+    if (text["status"] == "not started") { text["status"] = "not yet started"; }
+    // if (text["status"] == "fully materialized") { delete text["status"]; }
     text["total"] = text["time"];
     if (tree_node["details"]) {
       text["details"] = JSON.stringify(tree_node["details"]);

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -55,6 +55,8 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     if (queryUpdate.updateTimeStamp > lastQueryUpdate.updateTimeStamp) {
       runtime_log[runtime_log.length - 1] = runtime_info;
       query_log[query_log.length - 1] = query;
+    } else {
+      return;
     }
   } else {
     // Append to log and shorten log if too long (FIFO).

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -52,12 +52,11 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     parseInt(time["total"].toString().replace(/ms/, ""), 10);
 
   if (queryUpdate.queryId === lastQueryUpdate.queryId) {
-    if (queryUpdate.updateTimeStamp > lastQueryUpdate.updateTimeStamp) {
-      runtime_log[runtime_log.length - 1] = runtime_info;
-      query_log[query_log.length - 1] = query;
-    } else {
+    if (queryUpdate.updateTimeStamp <= lastQueryUpdate.updateTimeStamp) {
       return;
     }
+    runtime_log[runtime_log.length - 1] = runtime_info;
+    query_log[query_log.length - 1] = query;
   } else {
     // Append to log and shorten log if too long (FIFO).
     runtime_log[runtime_log.length] = runtime_info;
@@ -798,7 +797,7 @@ function displayError(queryId, response, statusWithText = undefined) {
     appendRuntimeInformation(response.runtimeInformation,
                              response.query,
                              response.time,
-                             { queryId, updateTimeStamp: Date.now() });
+                             { queryId, updateTimeStamp: Number.MAX_VALUE });
   }
 }
 

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -52,6 +52,7 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     parseInt(time["total"].toString().replace(/ms/, ""), 10);
 
   const previousTimeStamp = request_log.get(queryUpdate.queryId)?.timeStamp || Number.MIN_VALUE;
+  // If newer runtime info for existing query or new query.
   if (previousTimeStamp < queryUpdate.updateTimeStamp) {
     request_log.set(queryUpdate.queryId, {
       timeStamp: queryUpdate.updateTimeStamp,
@@ -59,6 +60,7 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
       query: query
     });
     if (request_log.size > 10) {
+      // Note: `keys().next()` is the key that was inserted first.
       request_log.delete(request_log.keys().next().value);
     }
   }

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -39,7 +39,7 @@ function normalizeQuery(query, escapeQuotes = false) {
 function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
   // Backwards compatability hack in case the info on the execution tree is
   // not in a separate "query_execution_tree" element yet.
-  if (runtime_info["query_execution_tree"] == undefined) {
+  if (runtime_info["query_execution_tree"] === undefined) {
     console.log("BACKWARDS compatibility hack: adding runtime_info[\"query_execution_tree\"]");
     runtime_info["query_execution_tree"] = structuredClone(runtime_info);
     runtime_info["meta"] = {};

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -51,22 +51,17 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
   runtime_info["meta"]["total_time"] =
     parseInt(time["total"].toString().replace(/ms/, ""), 10);
 
-  if (queryUpdate.queryId === lastQueryUpdate.queryId) {
-    if (queryUpdate.updateTimeStamp <= lastQueryUpdate.updateTimeStamp) {
-      return;
+  const previousTimeStamp = request_log.get(queryUpdate.queryId)?.timeStamp || Number.MIN_VALUE;
+  if (previousTimeStamp < queryUpdate.updateTimeStamp) {
+    request_log.set(queryUpdate.queryId, {
+      timeStamp: queryUpdate.updateTimeStamp,
+      runtime_info: runtime_info,
+      query: query
+    });
+    if (request_log.size > 10) {
+      request_log.delete(request_log.keys().next().value);
     }
-    runtime_log[runtime_log.length - 1] = runtime_info;
-    query_log[query_log.length - 1] = query;
-  } else {
-    // Append to log and shorten log if too long (FIFO).
-    if (runtime_log.length - 10 >= 0) {
-      runtime_log[runtime_log.length - 10] = null;
-      query_log[query_log.length - 10] = null;
-    }
-    runtime_log[runtime_log.length] = runtime_info;
-    query_log[query_log.length] = query;
   }
-  lastQueryUpdate = queryUpdate;
 }
 
 // Add "text" field to given `tree_node`, for display using Treant.js

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -114,7 +114,6 @@ function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cac
     text["cost-estimate"] = "[~ " + formatInteger(tree_node["estimated_operation_cost"]) + "]"
     text["status"] = tree_node["status"];
     if (text["status"] == "not started") { text["status"] = "not yet started"; }
-    // if (text["status"] == "fully materialized") { delete text["status"]; }
     text["total"] = text["time"];
     if (tree_node["details"]) {
       text["details"] = JSON.stringify(tree_node["details"]);

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -59,12 +59,12 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     query_log[query_log.length - 1] = query;
   } else {
     // Append to log and shorten log if too long (FIFO).
-    runtime_log[runtime_log.length] = runtime_info;
-    query_log[query_log.length] = query;
     if (runtime_log.length - 10 >= 0) {
       runtime_log[runtime_log.length - 10] = null;
       query_log[query_log.length - 10] = null;
     }
+    runtime_log[runtime_log.length] = runtime_info;
+    query_log[query_log.length] = query;
   }
   lastQueryUpdate = queryUpdate;
 }

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -69,13 +69,13 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
   lastQueryUpdate = queryUpdate;
 }
 
-// Add "text" field to given `tree_node`, for display using Treant.js (in
-// function `visualise` in `qleverUI.js`). This function call itself recursively
-// on each child of `tree_node` (if any).
+// Add "text" field to given `tree_node`, for display using Treant.js
+// (in function `renderRuntimeInformationToDom` in `qleverUI.js`).
+// This function call itself recursively on each child of `tree_node` (if any).
 //
 // NOTE: The labels and the style can be found in backend/static/css/style.css .
 // The coloring of the boxes, which depends on the time and caching status, is
-// done in function `visualise` in `qleverUI.js`.
+// done in function `renderRuntimeInformationToDom` in `qleverUI.js`.
 function addTextElementsToQueryExecutionTreeForTreant(tree_node, is_ancestor_cached = false) {
   if (tree_node["text"] == undefined) {
     var text = {};
@@ -753,7 +753,7 @@ function expandEditor() {
   }
 }
 
-function displayError(queryId, response, statusWithText = undefined) {
+function displayError(response, statusWithText = undefined, queryId = undefined) {
   console.error("Either the GET request failed or the backend returned an error:", response);
   if (response["exception"] == undefined || response["exception"] == "") {
     response["exception"] = "Unknown error";
@@ -792,12 +792,13 @@ function displayError(queryId, response, statusWithText = undefined) {
   // If error response contains query and runtime info, append to runtime log.
   //
   // TODO: Show items from error responses in different color (how about "red").
-  if (response["query"] && response["runtimeInformation"]) {
+  if (response["query"] && response["runtimeInformation"] && queryId) {
     // console.log("DEBUG: Error response with runtime information found!");
     appendRuntimeInformation(response.runtimeInformation,
                              response.query,
                              response.time,
                              { queryId, updateTimeStamp: Number.MAX_VALUE });
+    renderRuntimeInformationToDom();
   }
 }
 

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -706,20 +706,21 @@ function handleStatsDisplay() {
 }
 
 // Shows the modal containing the current runtime information tree
-function showQueryPlanningTree() {
+// calls renderRuntimeInformationToDom() afterwards to render it.
+function showQueryPlanningTree(number = undefined) {
   $("#visualisation").modal("show");
+  renderRuntimeInformationToDom(number);
 }
 
 // Uses the information inside of runtime_log and query_log
 // to populate the DOM with the current runtime information.
-// Use showQueryPlanningTree() to display it to the user.
-function renderRuntimeInformationToDom(number) {
+function renderRuntimeInformationToDom(number = undefined) {
   if (runtime_log.length === 0) {
     return;
   }
 
   // Get the right entries from the runtime log.
-  let runtime_log_index = number || runtime_log.length - 1;
+  let runtime_log_index = number !== undefined ? number : runtime_log.length - 1;
   let runtime_info = runtime_log[runtime_log_index];
   let resultQuery = query_log[runtime_log_index];
   
@@ -796,10 +797,7 @@ function renderRuntimeInformationToDom(number) {
         href: "#",
         text: `[${i}]`
       });
-      link.on("click", () => {
-        renderRuntimeInformationToDom(i);
-        showQueryPlanningTree();
-      });
+      link.on("click", () => showQueryPlanningTree(i));
       queryHistoryList.append($("<li/>", {
         class: "page-item",
         append: link

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -418,6 +418,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
           updateTimeStamp: Date.now()
         }
       );
+      visualise(false);
     }
   };
   ws.onerror = () => {
@@ -657,8 +658,10 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     });
   }
   
-  function visualise(number) {
-    $("#visualisation").modal("show");
+  function visualise(show, number) {
+    if (show) {
+      $("#visualisation").modal("show");
+    }
 
     // Get the right entries from the runtime log.
     runtime_log_index = number ? number - 1 : runtime_log.length - 1;
@@ -728,7 +731,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     if ($('#logRequests').is(':checked')) {
       select = "";
       for (var i = runtime_log.length; i > runtime_log.length - 10 && i > 0; i--) {
-        select = '<li class="page-item"><a class="page-link" href="javascript:void(0)" onclick="visualise(' + i + ')">[' + i + ']</a></li>' + select;
+        select = '<li class="page-item"><a class="page-link" href="javascript:void(0)" onclick="visualise(true, ' + i + ')">[' + i + ']</a></li>' + select;
       }
       select = '<ul class="pagination">' + select + '</ul>';
       $('#lastQueries').html(select);

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -674,11 +674,11 @@ function visualise(show, number) {
   let resultQuery = query_log[runtime_log_index];
   
   if (runtime_info["query_execution_tree"] === null) {
-    document.querySelector("#result-query").innerText = "";
-    document.querySelector("#meta-info").innerText = "";
-    const element = document.querySelector("#result-tree");
-    element.innerText = "Waiting for query...";
-    element.style.color = "green";
+    $("#result-query").text("");
+    $("#meta-info").text("");
+    const resultTree = $("#result-tree");
+    resultTree.text("Waiting for query...");
+    resultTree.css("color", "green");
     return;
   }
 

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -645,7 +645,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       // MAX_VALUE ensures this always has priority over the websocket updates
       appendRuntimeInformation(result.runtimeInformation, result.query, result.time, { queryId, updateTimeStamp: Number.MAX_VALUE });
       renderRuntimeInformationToDom();
-      
+
       // Make sure we have no socket that stays open forever
       ws.close();
     }
@@ -764,7 +764,13 @@ function renderRuntimeInformationToDom(number = undefined) {
     },
     nodeStructure: runtime_info["query_execution_tree"]
   }
+
+  // Draw the (new) tree, but retain the scrollbar position.
+  const scrollTop = $("#visualisation").scrollTop();
+  const scrollLeft = $("#result-tree").scrollLeft();
   new Treant(treant_tree);
+  $("#visualisation").scrollTop(scrollTop);
+  $("#result-tree").scrollLeft(scrollLeft);
 
   // For each node, on mouseover show the details.
   $("div.node").hover(function () {
@@ -789,7 +795,7 @@ function renderRuntimeInformationToDom(number = undefined) {
   $("p.node-status").filter(function() { return $(this).text() === "lazily materialized"}).addClass("lazily-materialized");
   $("p.node-status").filter(function() { return $(this).text() === "failed"}).addClass("failed");
   $("p.node-status").filter(function() { return $(this).text() === "failed because child failed"}).addClass("child-failed");
-  $("p.node-status").filter(function() { return $(this).text() === "not started"}).addClass("not-started");
+  $("p.node-status").filter(function() { return $(this).text() === "not yet started"}).parent().addClass("not-started");
   $("p.node-status").filter(function() { return $(this).text() === "optimized out"}).addClass("optimized-out");
   
   if ($('#logRequests').is(':checked')) {

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -6,12 +6,11 @@ var predicateNames = {};
 var objectNames = {};
 var high_query_time_ms = 100;
 var very_high_query_time_ms = 1000;
-// Map guarantees to keep insertion order
 var request_log = new Map();
 
 // Generates a random query id only known to this client.
 // We don't use consecutive ids to prevent clashes between
-// several qlever-ui instances.
+// different instances of the Qlever UI running at the same time.
 function generateQueryId() {
   if (window.isSecureContext) {
     return crypto.randomUUID();
@@ -805,6 +804,8 @@ function renderRuntimeInformationToDom(entry = undefined) {
   
   if ($('#logRequests').is(':checked')) {
     const queryHistoryList = $("<ul/>", { class: "pagination" });
+    // Note: when we later iterate over this `Map`, we get the key-value
+    // pairs in the order in which the keys were first inserted.
     for (const [key, value] of request_log.entries()) {
       const link = $("<a/>", {
         class: "page-link",

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -10,7 +10,9 @@ var runtime_log = [];
 var query_log = [];
 var lastQueryUpdate = { queryId: null, updateTimeStamp: 0 };
 
-// Generates a random query id only known to this client
+// Generates a random query id only known to this client.
+// We don't use consecutive ids to prevent clashes between
+// several qlever-ui instances.
 function generateQueryId() {
   if (window.isSecureContext) {
     return crypto.randomUUID();
@@ -23,7 +25,7 @@ function generateQueryId() {
 
 // Uses the BASEURL variable to build the URL for the websocket endpoint
 function getWebSocketUrl(queryId) {
-  return `${BASEURL.replaceAll(/^http/g, "ws")}/watch/${queryId}`;
+  return `${BASEURL.replace(/^http/g, "ws")}/watch/${queryId}`;
 }
 
 $(window).resize(function (e) {
@@ -395,7 +397,7 @@ function signalQueryStart(queryId, startTimeStamp, query) {
       total: `${Date.now() - startTimeStamp}ms`
     },
     {
-      queryId,
+      queryId: queryId,
       updateTimeStamp: startTimeStamp
     }
   );
@@ -710,7 +712,10 @@ function handleStatsDisplay() {
 
 // Shows the modal containing the current runtime information tree
 // calls renderRuntimeInformationToDom() afterwards to render it.
+// If number is explicitly given, this means a tree from the history
+// is rendered.
 function showQueryPlanningTree(number = undefined) {
+  // Modal needs to be visible for rendering to succeed
   $("#visualisation").modal("show");
   renderRuntimeInformationToDom(number);
 }

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -677,7 +677,7 @@ function visualise(show, number) {
     $("#result-query").text("");
     $("#meta-info").text("");
     const resultTree = $("#result-tree");
-    resultTree.text("Waiting for query...");
+    resultTree.text("Query was started, waiting for status updates...");
     resultTree.css("color", "green");
     return;
   }

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -402,6 +402,9 @@ function signalQueryStart(queryId, startTimeStamp, query) {
   renderRuntimeInformationToDom();
 }
 
+// Create a websocket object that listens for updates qlever
+// broadcasts during computation and update the current
+// runtime information in the log accordingly.
 function createWebSocketForQuery(queryId, startTimeStamp, query) {
   const ws = new WebSocket(getWebSocketUrl(queryId));
 

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -396,6 +396,22 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
   const queryId = crypto.randomUUID();
   const ws = new WebSocket(`${BASEURL.replaceAll(/^http/g, "ws")}/watch/${queryId}`);
   const startTimeStamp = Date.now();
+  
+  appendRuntimeInformation(
+    {
+      query_execution_tree: null,
+      meta: {}
+    },
+    params["query"],
+    {
+      computeResult: "0ms",
+      total: `${Date.now() - startTimeStamp}ms`
+    },
+    {
+      queryId,
+      updateTimeStamp: startTimeStamp
+    }
+  );
   ws.onopen = () => {
     log("Waiting for live updates", "other");
   };
@@ -665,10 +681,23 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       $("#visualisation").modal("show");
     }
 
+    if (runtime_log.length === 0) {
+      return;
+    }
+
     // Get the right entries from the runtime log.
     runtime_log_index = number ? number - 1 : runtime_log.length - 1;
     let runtime_info = runtime_log[runtime_log_index];
     let resultQuery = query_log[runtime_log_index];
+    
+    if (runtime_info["query_execution_tree"] === null) {
+      document.querySelector("#result-query").innerText = "";
+      document.querySelector("#meta-info").innerText = "";
+      const element = document.querySelector("#result-tree");
+      element.innerText = "Waiting for query...";
+      element.style.color = "green";
+      return;
+    }
 
     // Show meta information (if it exists).
     const meta_info = runtime_info["meta"]

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -403,15 +403,16 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     if (typeof message.data !== "string") {
       log("Unexpected message format", "other");
     } else {
+      const payload = JSON.parse(message.data);
       appendRuntimeInformation(
         {
-          query_execution_tree: JSON.parse(message.data),
+          query_execution_tree: payload,
           meta: {}
         },
         params["query"],
         {
-          computeResult: Date.now() - startTimeStamp,
-          total: Date.now() - startTimeStamp
+          computeResult: `${payload["total_time"] || (Date.now() - startTimeStamp)}ms`,
+          total: `${Date.now() - startTimeStamp}ms`
         },
         {
           queryId,
@@ -602,6 +603,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       
       // MAX_VALUE ensures this always has priority over the websocket updates
       appendRuntimeInformation(result.runtimeInformation, result.query, result.time, { queryId, updateTimeStamp: Number.MAX_VALUE });
+      visualise(false);
     }})
     .fail(function (jqXHR, textStatus, errorThrown) {
       $(element).find('.glyphicon').removeClass('glyphicon-spin glyphicon-refresh');

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -10,6 +10,16 @@ var runtime_log = [];
 var query_log = [];
 var lastQueryUpdate = { queryId: null, updateTimeStamp: 0 };
 
+function generateQueryId() {
+  if (window.isSecureContext) {
+    return crypto.randomUUID();
+  }
+  log("WARNING: Site is not served in secure context. " +
+      "Falling back to Math.random() for random value generation. " +
+      "Make sure this is not happening in production.", "other")
+  return Math.floor(Math.random() * 1000000000);
+}
+
 $(window).resize(function (e) {
   if (e.target == window) {
     editor.setSize($('#queryBlock').width());
@@ -392,7 +402,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     params["cmd"] = "clear-cache";
     nothingToShow = true;
   }
-  const queryId = crypto.randomUUID();
+  const queryId = generateQueryId();
   const ws = new WebSocket(`${BASEURL.replaceAll(/^http/g, "ws")}/watch/${queryId}`);
   const startTimeStamp = Date.now();
   

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -191,7 +191,7 @@
                   <button class="btn btn-default" onclick="processQuery(-1, this);">
                     <i class="glyphicon glyphicon-refresh"></i> Clear cache
                   </button>
-                  <button class="btn btn-default" onclick="visualise();">
+                  <button class="btn btn-default" onclick="visualise(true);">
                     <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
                   </button>
                   <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -191,7 +191,7 @@
                   <button class="btn btn-default" onclick="processQuery(-1, this);">
                     <i class="glyphicon glyphicon-refresh"></i> Clear cache
                   </button>
-                  <button class="btn btn-default" onclick="visualise(true);">
+                  <button class="btn btn-default" onclick="showQueryPlanningTree();">
                     <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
                   </button>
                   <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">


### PR DESCRIPTION
So far, the "Analysis" button for a query showed the query execution tree *after* the query processing finished (and also if it failed). Now the tree is shown as soon as the query planning is done and the information in the operation nodes is updated live after each operation. The communication is realized via web sockets. On the side of the QLever backend, the corresponding changes in the code were made in https://github.com/ad-freiburg/qlever/pull/1119 . 