### PR TITLE
Suggest geo:hasGeometry/geo:asWKT automagically

### DIFF
--- a/backend/static/js/codemirror/modes/sparql/sparql-hint.js
+++ b/backend/static/js/codemirror/modes/sparql/sparql-hint.js
@@ -516,6 +516,7 @@ function getDynamicSuggestions(context) {
             .replace(/^has([A-Z_-])/, "$1$")
             .replace(/^([a-z]+)edBy/, "$1$")
             .replace(/^(year)[A-Z_]\w*/, "$1$")
+            .replace(/^asWKT/, "geometry")
             .replace(/[^a-zA-Z0-9_]/g, "").toLowerCase();
 
           response.push('?' + objectVarName + ' .');
@@ -936,6 +937,15 @@ function getQleverSuggestions(
               displayText: "wdt:P131+ ",
               completion: "wdt:P131+ ",
               name: entityName + " (transitive)",
+              altname: altEntityName,
+              isMixedModeSuggestion: mainQueryHasTimedOut
+            });
+          }
+          else if (displayText == "geo:hasGeometry ") {
+            dynamicSuggestions.push({
+              displayText: "geo:hasGeometry/geo:asWKT ",
+              completion: "geo:hasGeometry/geo:asWKT ",
+              name: "geometry as WKT",
               altname: altEntityName,
               isMixedModeSuggestion: mainQueryHasTimedOut
             });

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -566,7 +566,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     // the Django configuration of the respective backend).
     var res = "<div id=\"res\">";
     if (showAllButton || (mapViewButtonVanilla && mapViewButtonPetri)) {
-      if (BASEURL.match("wikidata|osm-|dblp")) {
+      if (BASEURL.match("wikidata|osm|ohm|dblp")) {
         res += `<div class="pull-right" style="margin-left: 1em;">${showAllButton} ${mapViewButtonPetri}</div>`;
       } else {
         res += `<div class="pull-right" style="margin-left: 1em;">${showAllButton}</div>`;


### PR DESCRIPTION
For a while now, the TTL files on https://osm2rdf.cs.uni-freiburg.de provide the geometry WKTs via `geo:hasGeometry/geo:asWKT` (because that is how it should be according to the GeoSPARQL standard), and not directly via `geo:hasGeometry` as it used to be.

To ease query construction, the QLever UI now automagically suggests `geo:hasGeometry/geo:asWKT` whenever `geo:hasGeometry` is among the suggested predicates. We had a similar mechanism already for predicates like `wdt:P31` (in which case also `wdt:P31/wdt:P279*` is suggested).

When `geo:hasGeometry/geo:asWKT` is selected by the user, the variable name suggestion is `?geometry` and not `?as_wkt`.

On the side, also show the Map view button for OHM (when the result contains geometries in the last column, as usual).