### PR TITLE
No subject AC query for short prefix

### DIFF
--- a/backend/static/js/codemirror/modes/sparql/sparql-hint.js
+++ b/backend/static/js/codemirror/modes/sparql/sparql-hint.js
@@ -420,8 +420,11 @@ function getDynamicSuggestions(context) {
       }
     }
 
+    // Do not launch AC query when current word starts with ? or for subject AC
+    // queries when the prefix has length < 3.
+    var sendSparql = !(word.startsWith('?'))
+                       && !(words.length == 1 && words[0].length < 3);
     sparqlQuery = "";
-    var sendSparql = !(word.startsWith('?'));
     var sparqlLines = "";
     var mode1Query = "";  // mode 1 is context-insensitive
     var mode2Query = "";  // mode 2 is context-sensitive


### PR DESCRIPTION
Without typing at least a few characters, it's more confusing than helpful to suggest a subject AC query to the user. It is currently hard-coded that at least 3 characters have to be typed, but this should be a configurable parameter.