### PR TITLE
Display details for operation in "Analysis" tree as tooltip

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -59,7 +59,7 @@ Custom Elements
 }
 
 .tooltip .tooltip-inner { background-color: #82B36F; max-width: 600px; word-wrap: break-word; }
-.tooltip .tooltip-arrow { border-top-color: #82B36F !important; }
+.tooltip .tooltip-arrow { border-top-color: #82B36F !important; border-bottom-color: #82B36F !important; }
 
 
 .table > tbody > tr > td:first-child { color: #d3d3d3; }

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -821,11 +821,28 @@ function renderRuntimeInformationToDom(entry = undefined) {
   $("#visualisation").scrollTop(scrollTop);
   $("#result-tree").scrollLeft(scrollLeft);
 
-  // For each node, on mouseover show the details.
-  $("div.node").hover(function () {
-    $(this).children(".node-details").show();
-  }, function () {
-    $(this).children(".node-details").hide();
+  $("div.node").each(function () {
+    const details_childs = $(this).children(".node-details");
+    if (details_childs.length == 1) {
+      const top_pos = parseFloat($(this).css('top'));
+      $(this).attr("data-toggle", "tooltip" );
+      $(this).attr("data-html", "true" );
+      $(this).attr("data-placement",(top_pos>100?"top":"bottom"));
+      let detail_html = '';
+      const details = JSON.parse(details_childs[0].textContent);
+      for (const key in details) {
+        detail_html += `<span>${key}: <strong>${details[key]}</strong></span><br>`
+      }
+      $(this).attr("title",
+      `<div style="width: 250px">
+          <h5> Details </h5>
+          <hr style="margin-top: 0px; margin-bottom: 0px;">
+          <div style="margin-top: 10px; margin-bottom: 10px;">
+            ${detail_html}
+          </div>
+       </div>`);
+      $(this).tooltip();
+    }
   });
 
   $("p.node-time").


### PR DESCRIPTION
# Goal
This PR changes the way `details` are displayed in the query planning tree.
| before | after |
|-----------|---------|
| ![before](https://github.com/ad-freiburg/qlever-ui/assets/74186504/0016e2f9-8140-4599-a682-764211fc11b7)| ![after](https://github.com/ad-freiburg/qlever-ui/assets/74186504/0b7b2745-889b-4624-8f92-510699de031d)|

This is done with `tooltips`

# why its more Complicated than it should be
There are two issues i ran into, both seem to come from the combination of `Treant.js` and `popper.js`.
## 1. clipping
When the tooltip is outside of the Treant canvas, it just gets cut off.

To solve this i place the tooltip below the node if the y-position is below 20px.
That's a hack, but it seems to work fine.

| issue | fix |
|---------|-----|
| ![clipping-issue](https://github.com/ad-freiburg/qlever-ui/assets/74186504/fc5298a0-076a-4dbc-ac27-e8c2e19e5ffc) | ![clipping-fix](https://github.com/ad-freiburg/qlever-ui/assets/74186504/ba6d6ad4-05c1-4d5a-b79f-44e0e9fbf408) |

I tried placing the tooltip below for all nodes, that does not work for similar reasons.
I also spend some time fighting with the `z-index`, without success.

## 2. overflow
In large trees, where you need to scroll to the right, the tooltip's have a "wrong" width.

To solve this i just set the width to  `250px`.

| issue | fix |
|---------|-----|
| ![overflow-issue](https://github.com/ad-freiburg/qlever-ui/assets/74186504/39c5c393-e23d-43c4-a299-f16f02cf4db3) | ![overflow-fix](https://github.com/ad-freiburg/qlever-ui/assets/74186504/b7de1156-4624-467e-b576-84e6813668b7) |
