### PR TITLE
Update 'replace & search' shortcut to 'ctrl' + 'shift' + 'r'

### DIFF
--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -736,11 +736,11 @@ function changeTheme(theme = undefined) {
 }
 
 function expandEditor() {
-  if ($('#editorArea').hasClass("col-md-8")) {
-    $('#editorArea').removeClass("col-md-8").addClass("col-md-12");
+  if ($('#editorArea').hasClass("col-md-7")) {
+    $('#editorArea').removeClass("col-md-7").addClass("col-md-12");
     $('#help').hide();
   } else {
-    $('#editorArea').removeClass("col-md-12").addClass("col-md-8");
+    $('#editorArea').removeClass("col-md-12").addClass("col-md-7");
     $('#help').show();
   }
 }

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -111,7 +111,7 @@
                 <!-- The main editor (code mirror textarea) -->
                 <textarea id="query" class="form-control" placeholder="Start by typing SELECT or PREFIX ...">{% if prefill and not request.GET.test %}{{ prefill }}{% endif %}</textarea><br>
               </div>
-              <div class="col-md-4" id="help" style="display:none;">
+              <div class="col-md-5" id="help" style="display:none;">
                 <div id="uiHelp">  
                   <!-- The UI help box -->
                   <h4 style="margin-top: 0px;">QLever UI Shortcuts:</h4>
@@ -145,7 +145,7 @@
                       <td><em>Search in editor (supports RegEx)</em></td>
                     </tr>
                     <tr>
-                      <td><kbd>ctrl</kbd> + <kbd>r</kbd></td>
+                      <td><kbd>ctrl</kbd> + <kbd>shift</kbd> + <kbd>r</kbd></td>
                       <td><em>Search and replace in editor</em></td>
                     </tr>
                   </table>


### PR DESCRIPTION
This addresses Issue #81 and sets the advertised shortcut to `ctrl` + `shift` + `r`.

| before | after |
|-----------|---------|
| ![20240306_11h41m42s_grim](https://github.com/ad-freiburg/qlever-ui/assets/74186504/d095ad77-c916-45fa-9f62-235ec31d1c98) | ![20240306_11h45m54s_grim](https://github.com/ad-freiburg/qlever-ui/assets/74186504/6a704ff8-4a10-483b-9601-8091c577898f) |
 
 I personally would prefer the shortcut to actually be `ctrl` + `r`, since its the norm.
 Also `ctrl` + `shift` + `r` shadows the browser shortcut for "reload without cache", that i use on a regular basis.
 
 But i could not figure out where the keybinding is configured in 5 minutes and don't care that much. 