### PR TITLE
Update deprecated setting for static storage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM index.docker.io/library/python:3.12.4-alpine3.20
+ARG BASE_IMAGE=docker.io/python:3.12.5-alpine3.20
+
+FROM $BASE_IMAGE
+ARG BASE_IMAGE
 
 LABEL "org.opencontainers.image.url"="https://github.com/ad-freiburg/qlever-ui"
 LABEL "org.opencontainers.image.documentation"="https://github.com/ad-freiburg/qlever-ui"
@@ -6,7 +9,7 @@ LABEL "org.opencontainers.image.source"="https://github.com/ad-freiburg/qlever-u
 LABEL "org.opencontainers.image.licenses"="Apache-2.0"
 LABEL "org.opencontainers.image.title"="QLever UI"
 LABEL "org.opencontainers.image.description"="A user interface for QLever"
-LABEL "org.opencontainers.image.base"="index.docker.io/library/python:3.12.4-alpine3.20"
+LABEL "org.opencontainers.image.base"="$BASE_IMAGE"
 
 ADD requirements.txt /app/requirements.txt
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,4 @@
-ARG BASE_IMAGE=docker.io/python:3.12.5-alpine3.20
-
-FROM $BASE_IMAGE
-ARG BASE_IMAGE
-
-LABEL "org.opencontainers.image.url"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.documentation"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.source"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.licenses"="Apache-2.0"
-LABEL "org.opencontainers.image.title"="QLever UI"
-LABEL "org.opencontainers.image.description"="A user interface for QLever"
-LABEL "org.opencontainers.image.base"="$BASE_IMAGE"
+FROM index.docker.io/library/python:3.12.4-alpine3.20
 
 ADD requirements.txt /app/requirements.txt
 

--- a/qlever/settings.py
+++ b/qlever/settings.py
@@ -126,7 +126,16 @@ STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
 STATIC_VERSION = ""
 
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STORAGES = {
+    'default': {
+        # Django's default
+        'BACKEND': 'django.core.files.storage.FileSystemStorage'
+    },
+    'staticfiles': {
+        # Use WhiteNoise (https://whitenoise.readthedocs.io) for static file serving
+        'BACKEND': 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+    },
+}
 
 try:
     # Get git info from files in .git


### PR DESCRIPTION
So far, the variable for static storage in `settings.py` was called `STATICFILES_STORAGE`. Since Django 4.2, this is deprecated and now part of a dict called `STORAGES`.  See https://docs.djangoproject.com/en/5.1/ref/settings/#storages