### PR TITLE
Build and push Docker image after each commit to the master

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -3,8 +3,6 @@ name: Docker build and publish
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 concurrency:
   # When this is not a pull request, then we want all the docker containers to be pushed, we therefore
@@ -14,18 +12,15 @@ concurrency:
 
 jobs:
   docker:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          submodules: 'recursive'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -46,7 +41,6 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: "index"
 
       - name: Build and push
-        if: github.event_name != 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -61,8 +55,6 @@ jobs:
           # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
           tags: >
             adfreiburg/qlever-ui:latest,
-            adfreiburg/qlever-ui:${{ github.ref_name == 'master' && format('pr-{0}', steps.pr.outputs.pr_num) || github.ref_name }},
-            adfreiburg/qlever-ui:commit-${{ steps.sha.outputs.sha_short }},
 
           # Set Annotations and Labels that conform to the OpenContainers
           # Annotations Spec

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,71 @@
+name: Docker build and publish
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  # When this is not a pull request, then we want all the docker containers to be pushed, we therefore
+  # directly fall back to the commit hash which will be distinct for each push to master.
+  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.sha}}'
+  cancel-in-progress: true
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Get short sha
+        id: sha
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+      - name: Get PR number
+        id: pr
+        run: echo "pr_num=$(git log --format=%s -n 1 | sed -nr 's/.*\(\#([0-9]+)\)/\1/p')" >> $GITHUB_OUTPUT
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        env:
+          # We build multiplatform images which have an image index above the
+          # image manifests. Attach the annotations directly to the image index.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: "index"
+
+      - name: Build and push
+        if: github.event_name != 'pull_request'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+
+          # Push to dockerhub, reuse the cached steps from the previous build.
+          push: true
+
+          # If this is a push on master, publish with short commit sha
+          # else use the ref name, which has to be the tag in this case.
+          # We have to explicitly add the "qlever:latest" tag for it to work correctly,
+          # see e.g. https://stackoverflow.com/questions/27643017/do-i-need-to-manually-tag-latest-when-pushing-to-docker-public-repository
+          tags: >
+            adfreiburg/qlever-ui:latest,
+            adfreiburg/qlever-ui:${{ github.ref_name == 'master' && format('pr-{0}', steps.pr.outputs.pr_num) || github.ref_name }},
+            adfreiburg/qlever-ui:commit-${{ steps.sha.outputs.sha_short }},
+
+          # Set Annotations and Labels that conform to the OpenContainers
+          # Annotations Spec
+          annotations: ${{ steps.meta.outputs.annotations }}
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,5 @@
 FROM index.docker.io/library/python:3.12.4-alpine3.20
 
-LABEL "org.opencontainers.image.url"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.documentation"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.source"="https://github.com/ad-freiburg/qlever-ui"
-LABEL "org.opencontainers.image.licenses"="Apache-2.0"
-LABEL "org.opencontainers.image.title"="QLever UI"
-LABEL "org.opencontainers.image.description"="A user interface for QLever"
-LABEL "org.opencontainers.image.base"="index.docker.io/library/python:3.12.4-alpine3.20"
-
 ADD requirements.txt /app/requirements.txt
 
 RUN set -ex \


### PR DESCRIPTION
So far, Docker images were build and pushed to Docker Hub irregularly by Hannah. Now there is a GitHub action for this, which run after each commit to the master. Also, unlike before, these are now multiarch builds (for `linux/amd64` and `linux/arm64`). Addresses #96