### PR TITLE
Don't ignore `db` when building Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
-db
+!db
 .git
 !.git/HEAD
 !.git/refs/heads


### PR DESCRIPTION
We ignore this for our local image because there we mount the `db` directory as a volume. But for the Docker build and push action, it should of course not be ignored. This should fix #99 