### PR TITLE
Add command `prefixes` to obtain prefix definitions from backend config

### DIFF
--- a/backend/management/commands/prefixes.py
+++ b/backend/management/commands/prefixes.py
@@ -1,0 +1,49 @@
+from django.core.management.base import BaseCommand
+from backend.models import Backend
+import re
+
+
+# Command to get the PREFIX definitions from the given backend.
+class Command(BaseCommand):
+    help = "Usage: python manage.py examples <argument string>"
+
+    # Call the parent constructor.
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    # Log to the console.
+    def log(self, msg=""):
+        print(msg)
+
+    # Command line arguments.
+    def add_arguments(self, parser):
+        parser.add_argument("slug", nargs=1, help="Slug of the backend")
+
+    # This defines what the command does: it should return a string with one
+    # PREFIX definition per line.
+    def handle(self, *args, returnLog=False, **options):
+        # Get the slug from the command line arguments.
+        try:
+            slug = options["slug"][0]
+        except Exception as e:
+            self.log(f"Error parsing command line arguments: {e}")
+            self.log()
+            self.print_help("manage.py", "prefixes")
+            return
+        try:
+            backend = Backend.objects.filter(slug=slug).get()
+        except Exception as e:
+            self.log(f'Error finding config with slug "{slug}": {e}')
+            return
+        # Get the contents of the `suggestPrefixes` field. Replace `@prefix` by
+        # `PREFIX` at the beginning of each line and remove the `.` in the end
+        # if it is there. Also replace all whitespace by a single space and
+        # remove leading and trailing whitespace from each line.
+        prefix_defs = backend.suggestedPrefixes.split("\n")
+        for i, prefix_def in enumerate(prefix_defs):
+            prefix_def = re.sub(r"^@prefix", "PREFIX", prefix_def)
+            prefix_def = re.sub(r"\s*\.\s*$", "", prefix_def)
+            prefix_def = re.sub(r"\s+", " ", prefix_def)
+            prefix_def = prefix_def.strip()
+            prefix_defs[i] = prefix_def
+        return "\n".join(sorted(prefix_defs)) + "\n"

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,37 +6,31 @@ import datetime
 
 
 class Backend(models.Model):
-    MODES = (
-        (3, "4. Mixed mode"),
-        (2, "3. SPARQL & context sensitive entities"),
-        (1, "2. SPARQL & context insensitive entities"),
-        (0, "1. SPARQL syntax & keywords only"),
-    )
+    MODES = ((3, '4. Mixed mode'),
+             (2, '3. SPARQL & context sensitive entities'),
+             (1, '2. SPARQL & context insensitive entities'),
+             (0, '1. SPARQL syntax & keywords only'))
     useBackendDefaults = True
 
     name = models.CharField(
         max_length=500,
         help_text="Choose a name for the backend that helps you to distinguish between multiple backends",
         verbose_name="Name",
-        unique=True,
-    )
+        unique=True)
     slug = models.CharField(
         max_length=100,
         default="Empty",
         help_text="Name used in the URL of this backend; MUST only use valid URL characters (in particular, no space)",
-        verbose_name="Slug",
-    )
+        verbose_name="Slug")
     sortKey = models.CharField(
         max_length=10,
         default="0",
         help_text="Sort key, according to which backends are ordered lexicographically; DO NOT SHOW if this value is zero",
-        verbose_name="Sort Key",
-    )
+        verbose_name="Sort Key")
     baseUrl = models.CharField(
         max_length=1000,
         help_text="The URL where to find / call the QLever backend (including http://)",
-        verbose_name="Base URL",
-    )
+        verbose_name="Base URL")
 
     apiToken = models.CharField(
         max_length=32,
@@ -49,35 +43,30 @@ class Backend(models.Model):
     isDefault = models.BooleanField(
         default=0,
         help_text="Check if this should be the default backend for the QLever UI",
-        verbose_name="Use as default",
-    )
+        verbose_name="Use as default")
 
     isNoSlugMode = models.BooleanField(
         default=0,
         help_text="Check if this default backend should also be available without a slug in the QLever UI",
-        verbose_name="Enable no-slug mode",
-    )
+        verbose_name="Enable no-slug mode")
 
     maxDefault = models.IntegerField(
         default=100,
         help_text="The default for how many lines are shown in the first request",
-        verbose_name="Default Maximum",
-    )
+        verbose_name="Default Maximum")
 
     filteredLanguage = models.CharField(
         max_length=2000,
-        default="en",
+        default='en',
         help_text="Comma separated language codes used for filter suggestions",
-        verbose_name="Filter languages",
-    )
+        verbose_name="Filter languages")
 
     dynamicSuggestions = models.IntegerField(
         default=2,
         choices=MODES,
         help_text="Default for how to compute autocompletion queries if any",
-        verbose_name="Default autocompletion mode",
-    )
-
+        verbose_name="Default autocompletion mode")
+    
     defaultModeTimeout = models.FloatField(
         default=0,
         help_text="Default timeout in seconds for autocompletion queries",
@@ -90,70 +79,61 @@ class Backend(models.Model):
     )
 
     suggestSubjects = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-sensitive</em> subject autocompletion. Leave blank if you don't want subject suggestions.",
-        verbose_name="Subject autocompletion query",
-    )
+        verbose_name="Subject autocompletion query")
 
     suggestPredicates = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-sensitive</em> predicate autocompletion",
-        verbose_name="Predicate autocompletion query",
-    )
+        verbose_name="Predicate autocompletion query")
 
     suggestObjects = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-sensitive</em> object autocompletion",
-        verbose_name="Object autocompletion query",
-    )
+        verbose_name="Object autocompletion query")
 
     subjectName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpSubjectName\').slideToggle();">Need help?</a><div class="helpSubjectName" style="display: none;">Clause that tells QLever UI the name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the subject\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Subject name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpSubjectName').slideToggle();\">Need help?</a><div class=\"helpSubjectName\" style=\"display: none;\">Clause that tells QLever UI the name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the subject's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Subject name clause")
 
     alternativeSubjectName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativeSubjectName\').slideToggle();">Need help?</a><div class="helpAlternativeSubjectName" style="display: none;">Clause that tells QLever UI the alternative name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the subject\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Alternative subject name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativeSubjectName').slideToggle();\">Need help?</a><div class=\"helpAlternativeSubjectName\" style=\"display: none;\">Clause that tells QLever UI the alternative name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the subject's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Alternative subject name clause")
 
     predicateName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpPredicateName\').slideToggle();">Need help?</a><div class="helpPredicateName" style="display: none;">Clause that tells QLever UI the name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the predicate\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Predicate name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpPredicateName').slideToggle();\">Need help?</a><div class=\"helpPredicateName\" style=\"display: none;\">Clause that tells QLever UI the name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the predicate's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Predicate name clause")
 
     alternativePredicateName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativePredicateName\').slideToggle();">Need help?</a><div class="helpAlternativePredicateName" style="display: none;">Clause that tells QLever UI the alternative name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the predicate\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Alternative predicate name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativePredicateName').slideToggle();\">Need help?</a><div class=\"helpAlternativePredicateName\" style=\"display: none;\">Clause that tells QLever UI the alternative name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the predicate's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Alternative predicate name clause")
 
     objectName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpObjectName\').slideToggle();">Need help?</a><div class="helpObjectName" style="display: none;">Clause that tells QLever UI the name of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the object\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Object name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpObjectName').slideToggle();\">Need help?</a><div class=\"helpObjectName\" style=\"display: none;\">Clause that tells QLever UI the name of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the object's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Object name clause")
 
     alternativeObjectName = models.TextField(
-        default="",
+        default='',
         blank=True,
-        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativeObjectName\').slideToggle();">Need help?</a><div class="helpAlternativeObjectName" style="display: none;">Clause that tells QLever UI the alternativename of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the object\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
-        verbose_name="Alternative object name clause",
-    )
+        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativeObjectName').slideToggle();\">Need help?</a><div class=\"helpAlternativeObjectName\" style=\"display: none;\">Clause that tells QLever UI the alternativename of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the object's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
+        verbose_name="Alternative object name clause")
 
     replacePredicates = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="""<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.replacePredicates').slideToggle();\">Need help?</a><div class=\"replacePredicates\" style=\"display: none;\">
         A list of predicates that should be replaced for autocompletion.<br>
@@ -163,86 +143,75 @@ class Backend(models.Model):
         &lt;http://schema.org/name&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@en@&lt;http://schema.org/name&gt<br>
         &lt;http://wikiba.se/ontology#label&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@en@&lt;http://wikiba.se/ontology#label&gt;</div>
         """,
-        verbose_name="Replace predicates in autocompletion context.",
+        verbose_name="Replace predicates in autocompletion context."
     )
 
     supportedKeywords = models.TextField(
-        default="prefix, select, distinct, where, order, limit, offset, optional, by, as, having, not, textlimit, contains-entity, contains-word, filter, group, union, optional, has-predicate, minus, values",
+        default='prefix, select, distinct, where, order, limit, offset, optional, by, as, having, not, textlimit, contains-entity, contains-word, filter, group, union, optional, has-predicate, minus, values',
         blank=True,
         help_text="Comma separated list of SPARQL keywords supported by the backend. Will be used for keyword highlighting.",
-        verbose_name="Supported keywords",
-    )
+        verbose_name="Supported keywords")
 
     supportedFunctions = models.TextField(
-        default="asc, desc, avg, values, score, text, count, sample, min, max, average, concat, group_concat, langMatches, lang, regex, sum",
+        default='asc, desc, avg, values, score, text, count, sample, min, max, average, concat, group_concat, langMatches, lang, regex, sum',
         blank=True,
         help_text="Comma separated list of SPARQL functions supported by the backend. Will be used for function highlighting.",
-        verbose_name="Supported functions",
-    )
+        verbose_name="Supported functions")
 
     supportedPredicateSuggestions = models.TextField(
-        default="ql:contains-word, ql:contains-entity",
+        default='ql:contains-word, ql:contains-entity',
         blank=True,
         help_text="Comma separated list of predicate suggestions that should always be shown.",
-        verbose_name="Predicate suggestions",
-    )
+        verbose_name="Predicate suggestions")
 
     suggestPrefixnamesForPredicates = models.BooleanField(
         default=True,
         help_text="Suggest Prefix names without a particular entity when autocompleting predicates.",
-        verbose_name="Suggest prefix names for predicates.",
-    )
+        verbose_name="Suggest prefix names for predicates.")
 
     fillPrefixes = models.BooleanField(
         default=True,
         help_text="Replace prefixes in suggestions even if they are not yet declared in the query. Add prefix declarations if a suggestion with not yet declared prefix is picked.",
-        verbose_name="Fill in known Prefixes",
-    )
+        verbose_name="Fill in known Prefixes")
 
     filterEntities = models.BooleanField(
         default=False,
         help_text="Also suggest FILTER for variables that store entity IDs. You can use this if you don't have name relations and your entity IDs and names are equal.",
-        verbose_name="Suggest FILTER for entity variables",
-    )
+        verbose_name="Suggest FILTER for entity variables")
 
     suggestedPrefixes = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="A list of prefixes that should be suggested. Prefixes can have either of these forms:<ul><li>@prefix schema: &lt;https://www.schema.org/&gt; .</li><li>Prefix schema: &lt;http://schema.org/&gt;</li></ul>",
-        verbose_name="Suggested Prefixes",
-    )
+        verbose_name="Suggested Prefixes")
 
     suggestionEntityVariable = models.CharField(
         max_length=100,
-        default="",
+        default='',
         blank=True,
         help_text="The variable that stores the suggested entity in the following queries.",
-        verbose_name="Variable for suggested entity",
-    )
+        verbose_name="Variable for suggested entity")
 
     suggestionNameVariable = models.CharField(
         max_length=100,
-        default="",
+        default='',
         blank=True,
         help_text="The variable that stores the name of the suggestion in the following queries.",
-        verbose_name="Variable for suggestion name",
-    )
+        verbose_name="Variable for suggestion name")
 
     suggestionAltNameVariable = models.CharField(
         max_length=100,
-        default="",
+        default='',
         blank=True,
         help_text="The variable that stores the alternative name of the suggestion in the following queries.",
-        verbose_name="Variable for alternative suggestion name",
-    )
+        verbose_name="Variable for alternative suggestion name")
 
     suggestionReversedVariable = models.CharField(
         max_length=100,
-        default="",
+        default='',
         blank=True,
         help_text="The variable that stores wether a suggestion is reversed.",
-        verbose_name="Variable for reversed suggestion",
-    )
+        verbose_name="Variable for reversed suggestion")
 
     # variables for cache pinning
     frequentPredicates = models.TextField(
@@ -343,30 +312,27 @@ class Backend(models.Model):
     )
 
     suggestSubjectsContextInsensitive = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-insensitive<em> subject autocompletion. Leave blank if you don't want subject suggestions.",
-        verbose_name="Context-insensitive subject autocompletion query",
-    )
+        verbose_name="Context-insensitive subject autocompletion query")
 
     suggestPredicatesContextInsensitive = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-insensitive</em> predicate autocompletion",
-        verbose_name="Context-insensitive predicate autocompletion query",
-    )
+        verbose_name="Context-insensitive predicate autocompletion query")
 
     suggestObjectsContextInsensitive = models.TextField(
-        default="",
+        default='',
         blank=True,
         help_text="The query for <em>context-insensitive</em> object autocompletion",
-        verbose_name="Context-insensitive object autocompletion query",
-    )
+        verbose_name="Context-insensitive object autocompletion query")
 
     mapViewBaseURL = models.CharField(
         default="",
         blank=True,
-        max_length=2048,  # URLs don't have a length limit, but this should be plenty long
+        max_length=2048, # URLs don't have a length limit, but this should be plenty long
         verbose_name="Map view base URL",
         help_text="The base URL of the https://github.com/ad-freiburg/qlever-petrimaps instance; if empty, no Map View button will appear",
     )
@@ -374,27 +340,15 @@ class Backend(models.Model):
     def save(self, *args, **kwargs):
         # We need to replace \r because QLever can't handle them very well
         for field in (
-            "subjectName",
-            "predicateName",
-            "objectName",
-            "suggestSubjects",
-            "suggestPredicates",
-            "suggestObjects",
-            "alternativeSubjectName",
-            "alternativePredicateName",
-            "alternativeObjectName",
-            "suggestSubjectsContextInsensitive",
-            "suggestPredicatesContextInsensitive",
-            "suggestObjectsContextInsensitive",
-        ):
-            setattr(
-                self,
-                field,
-                str(getattr(self, field)).replace("\r\n", "\n").replace("\r", "\n"),
-            )
+            'subjectName', 'predicateName', 'objectName',
+            'suggestSubjects', 'suggestPredicates', 'suggestObjects',
+            'alternativeSubjectName', 'alternativePredicateName', 'alternativeObjectName',
+            'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive'):
+            setattr(self, field, str(getattr(self, field)).replace(
+                "\r\n", "\n").replace("\r", "\n"))
         super(Backend, self).save(*args, **kwargs)
 
-        if self.isDefault:
+        if self.isDefault == True:
             Backend.objects.exclude(pk=self.pk).update(isDefault=False)
             Backend.objects.exclude(pk=self.pk).update(isNoSlugMode=False)
 
@@ -410,21 +364,21 @@ class Backend(models.Model):
     def languages(self):
         jsArray = "["
         for val in self.filteredLanguage.split(","):
-            jsArray += "'\"" + val.strip() + "\"',"
+            jsArray += '\'"'+val.strip()+'"\','
         jsArray += "]"
         return jsArray
 
     def keywords(self):
         jsArray = "["
         for val in self.supportedKeywords.split(","):
-            jsArray += '"' + val.strip() + '",'
+            jsArray += '"'+val.strip()+'",'
         jsArray += "]"
         return jsArray
 
     def functions(self):
         jsArray = "["
         for val in self.supportedFunctions.split(","):
-            jsArray += '"' + val.strip() + '",'
+            jsArray += '"'+val.strip()+'",'
         jsArray += "]"
         return jsArray
 
@@ -432,26 +386,17 @@ class Backend(models.Model):
         jsArray = "["
         for val in self.supportedPredicateSuggestions.split(","):
             if val:
-                jsArray += '"' + val.strip() + '",'
+                jsArray += '"'+val.strip()+'",'
         jsArray += "]"
         return jsArray
 
     def entityNameQueries(self):
         data = {}
         for field in (
-            "subjectName",
-            "predicateName",
-            "objectName",
-            "suggestSubjects",
-            "suggestPredicates",
-            "suggestObjects",
-            "alternativeSubjectName",
-            "alternativePredicateName",
-            "alternativeObjectName",
-            "suggestSubjectsContextInsensitive",
-            "suggestPredicatesContextInsensitive",
-            "suggestObjectsContextInsensitive",
-        ):
+            'subjectName', 'predicateName', 'objectName',
+            'suggestSubjects', 'suggestPredicates', 'suggestObjects',
+            'alternativeSubjectName', 'alternativePredicateName', 'alternativeObjectName',
+            'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive'):
             data[field.upper()] = getattr(self, field)
         return json.dumps(data)
 
@@ -484,10 +429,8 @@ class Backend(models.Model):
     @property
     def availablePrefixes(self):
         prefixes = {}
-        for match in re.findall(
-            r"prefix\s+(\S+):\s+(\S+)", self.suggestedPrefixes, re.IGNORECASE
-        ):
-            prefixes[match[0]] = match[1].strip("<>")
+        for match in re.findall(r"prefix\s+(\S+):\s+(\S+)", self.suggestedPrefixes, re.IGNORECASE):
+            prefixes[match[0]] = match[1].strip('<>')
         return prefixes
 
     @cached_property
@@ -497,15 +440,8 @@ class Backend(models.Model):
     def __getattribute__(self, name, forceUseDefault=False):
         value = super().__getattribute__(name)
         try:
-            useDefault = forceUseDefault or super().__getattribute__(
-                "useBackendDefaults"
-            )
-            if (
-                useDefault
-                and not value
-                and super().__getattribute__("backendDefaults")
-                and name in BackendDefaults.AVAILABLE_DEFAULTS
-            ):
+            useDefault = forceUseDefault or super().__getattribute__("useBackendDefaults")
+            if useDefault and not value and super().__getattribute__("backendDefaults") and name in BackendDefaults.AVAILABLE_DEFAULTS:
                 value = getattr(self.backendDefaults, name)
         except RecursionError:
             pass  # during imports, the backend defaults don't work and would throw an error
@@ -516,38 +452,22 @@ class Backend(models.Model):
 class BackendDefaults(Backend):
     # every field name listed in AVAILABLE_DEFAULTS will automatically appear in the Backend Defaults admin
     # And will automatically be used as default for every Backend
-    AVAILABLE_DEFAULTS = (
-        "suggestionEntityVariable",
-        "suggestionNameVariable",
-        "suggestionAltNameVariable",
-        "suggestionReversedVariable",
-        "suggestSubjects",
-        "suggestPredicates",
-        "suggestObjects",
-        "entityNameAndAliasPattern",
-        "entityScorePattern",
-        "predicateNameAndAliasPatternWithoutContext",
-        "predicateNameAndAliasPatternWithContext",
-        "entityNameAndAliasPatternDefault",
-        "predicateNameAndAliasPatternWithoutContextDefault",
-        "predicateNameAndAliasPatternWithContextDefault",
-        "warmupQuery1",
-        "warmupQuery2",
-        "warmupQuery3",
-        "warmupQuery4",
-        "warmupQuery5",
-        "suggestSubjectsContextInsensitive",
-        "suggestPredicatesContextInsensitive",
-        "suggestObjectsContextInsensitive",
-        "apiToken",
-    )
+    AVAILABLE_DEFAULTS = ("suggestionEntityVariable", "suggestionNameVariable", "suggestionAltNameVariable",
+                          "suggestionReversedVariable", "suggestSubjects", "suggestPredicates", "suggestObjects",
+                          "entityNameAndAliasPattern", "entityScorePattern", "predicateNameAndAliasPatternWithoutContext",
+                          "predicateNameAndAliasPatternWithContext", "entityNameAndAliasPatternDefault",
+                          "predicateNameAndAliasPatternWithoutContextDefault", "predicateNameAndAliasPatternWithContextDefault",
+                          "warmupQuery1", "warmupQuery2", "warmupQuery3", "warmupQuery4", "warmupQuery5",
+                          'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive',
+                          'apiToken')
 
     class Meta:
         verbose_name_plural = "Backend defaults"
 
     def save(self, *args, **kwargs):
         self.name = "Global defaults for all Backends"
-        self.slug = "globaldefaults_" + str(datetime.datetime.now().timestamp())
+        self.slug = "globaldefaults_" + \
+            str(datetime.datetime.now().timestamp())
         self.sortKey = "0"
         self.baseUrl = ""
         self.isDefault = False
@@ -565,18 +485,14 @@ class Link(models.Model):
 class Example(models.Model):
     backend = models.ForeignKey(Backend, on_delete=models.CASCADE)
     name = models.CharField(
-        max_length=100, help_text="Name of this example to show in the user interface"
-    )
+        max_length=100, help_text="Name of this example to show in the user interface")
     query = models.TextField()
     sortKey = models.CharField(
-        max_length=100,
-        default="~",
-        help_text=(
-            "Sort key, according to which example queries are ordered lexicographically"
-            "; default is '~', which is larger than most characters"
-        ),
-        verbose_name="Sort key",
-    )
+            max_length=100,
+            default="~",
+            help_text=("Sort key, according to which example queries are ordered lexicographically"
+                       "; default is '~', which is larger than most characters"),
+            verbose_name="Sort key")
 
     def __str__(self):
         return self.name

--- a/backend/models.py
+++ b/backend/models.py
@@ -6,31 +6,37 @@ import datetime
 
 
 class Backend(models.Model):
-    MODES = ((3, '4. Mixed mode'),
-             (2, '3. SPARQL & context sensitive entities'),
-             (1, '2. SPARQL & context insensitive entities'),
-             (0, '1. SPARQL syntax & keywords only'))
+    MODES = (
+        (3, "4. Mixed mode"),
+        (2, "3. SPARQL & context sensitive entities"),
+        (1, "2. SPARQL & context insensitive entities"),
+        (0, "1. SPARQL syntax & keywords only"),
+    )
     useBackendDefaults = True
 
     name = models.CharField(
         max_length=500,
         help_text="Choose a name for the backend that helps you to distinguish between multiple backends",
         verbose_name="Name",
-        unique=True)
+        unique=True,
+    )
     slug = models.CharField(
         max_length=100,
         default="Empty",
         help_text="Name used in the URL of this backend; MUST only use valid URL characters (in particular, no space)",
-        verbose_name="Slug")
+        verbose_name="Slug",
+    )
     sortKey = models.CharField(
         max_length=10,
         default="0",
         help_text="Sort key, according to which backends are ordered lexicographically; DO NOT SHOW if this value is zero",
-        verbose_name="Sort Key")
+        verbose_name="Sort Key",
+    )
     baseUrl = models.CharField(
         max_length=1000,
         help_text="The URL where to find / call the QLever backend (including http://)",
-        verbose_name="Base URL")
+        verbose_name="Base URL",
+    )
 
     apiToken = models.CharField(
         max_length=32,
@@ -43,30 +49,35 @@ class Backend(models.Model):
     isDefault = models.BooleanField(
         default=0,
         help_text="Check if this should be the default backend for the QLever UI",
-        verbose_name="Use as default")
+        verbose_name="Use as default",
+    )
 
     isNoSlugMode = models.BooleanField(
         default=0,
         help_text="Check if this default backend should also be available without a slug in the QLever UI",
-        verbose_name="Enable no-slug mode")
+        verbose_name="Enable no-slug mode",
+    )
 
     maxDefault = models.IntegerField(
         default=100,
         help_text="The default for how many lines are shown in the first request",
-        verbose_name="Default Maximum")
+        verbose_name="Default Maximum",
+    )
 
     filteredLanguage = models.CharField(
         max_length=2000,
-        default='en',
+        default="en",
         help_text="Comma separated language codes used for filter suggestions",
-        verbose_name="Filter languages")
+        verbose_name="Filter languages",
+    )
 
     dynamicSuggestions = models.IntegerField(
         default=2,
         choices=MODES,
         help_text="Default for how to compute autocompletion queries if any",
-        verbose_name="Default autocompletion mode")
-    
+        verbose_name="Default autocompletion mode",
+    )
+
     defaultModeTimeout = models.FloatField(
         default=0,
         help_text="Default timeout in seconds for autocompletion queries",
@@ -79,61 +90,70 @@ class Backend(models.Model):
     )
 
     suggestSubjects = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-sensitive</em> subject autocompletion. Leave blank if you don't want subject suggestions.",
-        verbose_name="Subject autocompletion query")
+        verbose_name="Subject autocompletion query",
+    )
 
     suggestPredicates = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-sensitive</em> predicate autocompletion",
-        verbose_name="Predicate autocompletion query")
+        verbose_name="Predicate autocompletion query",
+    )
 
     suggestObjects = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-sensitive</em> object autocompletion",
-        verbose_name="Object autocompletion query")
+        verbose_name="Object autocompletion query",
+    )
 
     subjectName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpSubjectName').slideToggle();\">Need help?</a><div class=\"helpSubjectName\" style=\"display: none;\">Clause that tells QLever UI the name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the subject's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Subject name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpSubjectName\').slideToggle();">Need help?</a><div class="helpSubjectName" style="display: none;">Clause that tells QLever UI the name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the subject\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Subject name clause",
+    )
 
     alternativeSubjectName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativeSubjectName').slideToggle();\">Need help?</a><div class=\"helpAlternativeSubjectName\" style=\"display: none;\">Clause that tells QLever UI the alternative name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the subject's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Alternative subject name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativeSubjectName\').slideToggle();">Need help?</a><div class="helpAlternativeSubjectName" style="display: none;">Clause that tells QLever UI the alternative name of a subject (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The subject that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the subject\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;?qleverui_entity &lt;predicate&gt; &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative subject name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Alternative subject name clause",
+    )
 
     predicateName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpPredicateName').slideToggle();\">Need help?</a><div class=\"helpPredicateName\" style=\"display: none;\">Clause that tells QLever UI the name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the predicate's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Predicate name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpPredicateName\').slideToggle();">Need help?</a><div class="helpPredicateName" style="display: none;">Clause that tells QLever UI the name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the predicate\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Predicate name clause",
+    )
 
     alternativePredicateName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativePredicateName').slideToggle();\">Need help?</a><div class=\"helpAlternativePredicateName\" style=\"display: none;\">Clause that tells QLever UI the alternative name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the predicate's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Alternative predicate name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativePredicateName\').slideToggle();">Need help?</a><div class="helpAlternativePredicateName" style="display: none;">Clause that tells QLever UI the alternative name of a predicate (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The predicate that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the predicate\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; ?qleverui_entity &lt;object&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative predicate name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Alternative predicate name clause",
+    )
 
     objectName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpObjectName').slideToggle();\">Need help?</a><div class=\"helpObjectName\" style=\"display: none;\">Clause that tells QLever UI the name of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the object's name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Object name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpObjectName\').slideToggle();">Need help?</a><div class="helpObjectName" style="display: none;">Clause that tells QLever UI the name of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_name: The variable that will hold the object\'s name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_name WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Object name clause",
+    )
 
     alternativeObjectName = models.TextField(
-        default='',
+        default="",
         blank=True,
-        help_text="<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.helpAlternativeObjectName').slideToggle();\">Need help?</a><div class=\"helpAlternativeObjectName\" style=\"display: none;\">Clause that tells QLever UI the alternativename of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the object's alternative name<br>Your clause should end in a dot '.' or closing bracket '}'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>",
-        verbose_name="Alternative object name clause")
+        help_text='<a href="javascript:void(0)" onclick="django.jQuery(\'.helpAlternativeObjectName\').slideToggle();">Need help?</a><div class="helpAlternativeObjectName" style="display: none;">Clause that tells QLever UI the alternativename of an object (without prefixes). Qlever UI expects the following variables to be used:<br>&nbsp;&nbsp;- &nbsp;?qleverui_entity: The object that we want to get the name of<br>&nbsp;&nbsp;- &nbsp;?qleverui_altname: The variable that will hold the object\'s alternative name<br>Your clause should end in a dot \'.\' or closing bracket \'}\'<br>Your clause will be used as following:<br>SELECT ?qleverui_altname WHERE {<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;subject&gt; &lt;predicate&gt; ?qleverui_entity<br>&nbsp;&nbsp;&nbsp;&nbsp;OPTIONAL {<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<b><em>alternative object name clause</em></b><br>&nbsp;&nbsp;&nbsp;&nbsp;}<br>}</div>',
+        verbose_name="Alternative object name clause",
+    )
 
     replacePredicates = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="""<a href=\"javascript:void(0)\" onclick=\"django.jQuery('.replacePredicates').slideToggle();\">Need help?</a><div class=\"replacePredicates\" style=\"display: none;\">
         A list of predicates that should be replaced for autocompletion.<br>
@@ -143,75 +163,86 @@ class Backend(models.Model):
         &lt;http://schema.org/name&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@en@&lt;http://schema.org/name&gt<br>
         &lt;http://wikiba.se/ontology#label&gt;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;@en@&lt;http://wikiba.se/ontology#label&gt;</div>
         """,
-        verbose_name="Replace predicates in autocompletion context."
+        verbose_name="Replace predicates in autocompletion context.",
     )
 
     supportedKeywords = models.TextField(
-        default='prefix, select, distinct, where, order, limit, offset, optional, by, as, having, not, textlimit, contains-entity, contains-word, filter, group, union, optional, has-predicate, minus, values',
+        default="prefix, select, distinct, where, order, limit, offset, optional, by, as, having, not, textlimit, contains-entity, contains-word, filter, group, union, optional, has-predicate, minus, values",
         blank=True,
         help_text="Comma separated list of SPARQL keywords supported by the backend. Will be used for keyword highlighting.",
-        verbose_name="Supported keywords")
+        verbose_name="Supported keywords",
+    )
 
     supportedFunctions = models.TextField(
-        default='asc, desc, avg, values, score, text, count, sample, min, max, average, concat, group_concat, langMatches, lang, regex, sum',
+        default="asc, desc, avg, values, score, text, count, sample, min, max, average, concat, group_concat, langMatches, lang, regex, sum",
         blank=True,
         help_text="Comma separated list of SPARQL functions supported by the backend. Will be used for function highlighting.",
-        verbose_name="Supported functions")
+        verbose_name="Supported functions",
+    )
 
     supportedPredicateSuggestions = models.TextField(
-        default='ql:contains-word, ql:contains-entity',
+        default="ql:contains-word, ql:contains-entity",
         blank=True,
         help_text="Comma separated list of predicate suggestions that should always be shown.",
-        verbose_name="Predicate suggestions")
+        verbose_name="Predicate suggestions",
+    )
 
     suggestPrefixnamesForPredicates = models.BooleanField(
         default=True,
         help_text="Suggest Prefix names without a particular entity when autocompleting predicates.",
-        verbose_name="Suggest prefix names for predicates.")
+        verbose_name="Suggest prefix names for predicates.",
+    )
 
     fillPrefixes = models.BooleanField(
         default=True,
         help_text="Replace prefixes in suggestions even if they are not yet declared in the query. Add prefix declarations if a suggestion with not yet declared prefix is picked.",
-        verbose_name="Fill in known Prefixes")
+        verbose_name="Fill in known Prefixes",
+    )
 
     filterEntities = models.BooleanField(
         default=False,
         help_text="Also suggest FILTER for variables that store entity IDs. You can use this if you don't have name relations and your entity IDs and names are equal.",
-        verbose_name="Suggest FILTER for entity variables")
+        verbose_name="Suggest FILTER for entity variables",
+    )
 
     suggestedPrefixes = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="A list of prefixes that should be suggested. Prefixes can have either of these forms:<ul><li>@prefix schema: &lt;https://www.schema.org/&gt; .</li><li>Prefix schema: &lt;http://schema.org/&gt;</li></ul>",
-        verbose_name="Suggested Prefixes")
+        verbose_name="Suggested Prefixes",
+    )
 
     suggestionEntityVariable = models.CharField(
         max_length=100,
-        default='',
+        default="",
         blank=True,
         help_text="The variable that stores the suggested entity in the following queries.",
-        verbose_name="Variable for suggested entity")
+        verbose_name="Variable for suggested entity",
+    )
 
     suggestionNameVariable = models.CharField(
         max_length=100,
-        default='',
+        default="",
         blank=True,
         help_text="The variable that stores the name of the suggestion in the following queries.",
-        verbose_name="Variable for suggestion name")
+        verbose_name="Variable for suggestion name",
+    )
 
     suggestionAltNameVariable = models.CharField(
         max_length=100,
-        default='',
+        default="",
         blank=True,
         help_text="The variable that stores the alternative name of the suggestion in the following queries.",
-        verbose_name="Variable for alternative suggestion name")
+        verbose_name="Variable for alternative suggestion name",
+    )
 
     suggestionReversedVariable = models.CharField(
         max_length=100,
-        default='',
+        default="",
         blank=True,
         help_text="The variable that stores wether a suggestion is reversed.",
-        verbose_name="Variable for reversed suggestion")
+        verbose_name="Variable for reversed suggestion",
+    )
 
     # variables for cache pinning
     frequentPredicates = models.TextField(
@@ -312,27 +343,30 @@ class Backend(models.Model):
     )
 
     suggestSubjectsContextInsensitive = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-insensitive<em> subject autocompletion. Leave blank if you don't want subject suggestions.",
-        verbose_name="Context-insensitive subject autocompletion query")
+        verbose_name="Context-insensitive subject autocompletion query",
+    )
 
     suggestPredicatesContextInsensitive = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-insensitive</em> predicate autocompletion",
-        verbose_name="Context-insensitive predicate autocompletion query")
+        verbose_name="Context-insensitive predicate autocompletion query",
+    )
 
     suggestObjectsContextInsensitive = models.TextField(
-        default='',
+        default="",
         blank=True,
         help_text="The query for <em>context-insensitive</em> object autocompletion",
-        verbose_name="Context-insensitive object autocompletion query")
+        verbose_name="Context-insensitive object autocompletion query",
+    )
 
     mapViewBaseURL = models.CharField(
         default="",
         blank=True,
-        max_length=2048, # URLs don't have a length limit, but this should be plenty long
+        max_length=2048,  # URLs don't have a length limit, but this should be plenty long
         verbose_name="Map view base URL",
         help_text="The base URL of the https://github.com/ad-freiburg/qlever-petrimaps instance; if empty, no Map View button will appear",
     )
@@ -340,15 +374,27 @@ class Backend(models.Model):
     def save(self, *args, **kwargs):
         # We need to replace \r because QLever can't handle them very well
         for field in (
-            'subjectName', 'predicateName', 'objectName',
-            'suggestSubjects', 'suggestPredicates', 'suggestObjects',
-            'alternativeSubjectName', 'alternativePredicateName', 'alternativeObjectName',
-            'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive'):
-            setattr(self, field, str(getattr(self, field)).replace(
-                "\r\n", "\n").replace("\r", "\n"))
+            "subjectName",
+            "predicateName",
+            "objectName",
+            "suggestSubjects",
+            "suggestPredicates",
+            "suggestObjects",
+            "alternativeSubjectName",
+            "alternativePredicateName",
+            "alternativeObjectName",
+            "suggestSubjectsContextInsensitive",
+            "suggestPredicatesContextInsensitive",
+            "suggestObjectsContextInsensitive",
+        ):
+            setattr(
+                self,
+                field,
+                str(getattr(self, field)).replace("\r\n", "\n").replace("\r", "\n"),
+            )
         super(Backend, self).save(*args, **kwargs)
 
-        if self.isDefault == True:
+        if self.isDefault:
             Backend.objects.exclude(pk=self.pk).update(isDefault=False)
             Backend.objects.exclude(pk=self.pk).update(isNoSlugMode=False)
 
@@ -364,21 +410,21 @@ class Backend(models.Model):
     def languages(self):
         jsArray = "["
         for val in self.filteredLanguage.split(","):
-            jsArray += '\'"'+val.strip()+'"\','
+            jsArray += "'\"" + val.strip() + "\"',"
         jsArray += "]"
         return jsArray
 
     def keywords(self):
         jsArray = "["
         for val in self.supportedKeywords.split(","):
-            jsArray += '"'+val.strip()+'",'
+            jsArray += '"' + val.strip() + '",'
         jsArray += "]"
         return jsArray
 
     def functions(self):
         jsArray = "["
         for val in self.supportedFunctions.split(","):
-            jsArray += '"'+val.strip()+'",'
+            jsArray += '"' + val.strip() + '",'
         jsArray += "]"
         return jsArray
 
@@ -386,17 +432,26 @@ class Backend(models.Model):
         jsArray = "["
         for val in self.supportedPredicateSuggestions.split(","):
             if val:
-                jsArray += '"'+val.strip()+'",'
+                jsArray += '"' + val.strip() + '",'
         jsArray += "]"
         return jsArray
 
     def entityNameQueries(self):
         data = {}
         for field in (
-            'subjectName', 'predicateName', 'objectName',
-            'suggestSubjects', 'suggestPredicates', 'suggestObjects',
-            'alternativeSubjectName', 'alternativePredicateName', 'alternativeObjectName',
-            'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive'):
+            "subjectName",
+            "predicateName",
+            "objectName",
+            "suggestSubjects",
+            "suggestPredicates",
+            "suggestObjects",
+            "alternativeSubjectName",
+            "alternativePredicateName",
+            "alternativeObjectName",
+            "suggestSubjectsContextInsensitive",
+            "suggestPredicatesContextInsensitive",
+            "suggestObjectsContextInsensitive",
+        ):
             data[field.upper()] = getattr(self, field)
         return json.dumps(data)
 
@@ -429,8 +484,10 @@ class Backend(models.Model):
     @property
     def availablePrefixes(self):
         prefixes = {}
-        for match in re.findall(r"prefix\s+(\S+):\s+(\S+)", self.suggestedPrefixes, re.IGNORECASE):
-            prefixes[match[0]] = match[1].strip('<>')
+        for match in re.findall(
+            r"prefix\s+(\S+):\s+(\S+)", self.suggestedPrefixes, re.IGNORECASE
+        ):
+            prefixes[match[0]] = match[1].strip("<>")
         return prefixes
 
     @cached_property
@@ -440,8 +497,15 @@ class Backend(models.Model):
     def __getattribute__(self, name, forceUseDefault=False):
         value = super().__getattribute__(name)
         try:
-            useDefault = forceUseDefault or super().__getattribute__("useBackendDefaults")
-            if useDefault and not value and super().__getattribute__("backendDefaults") and name in BackendDefaults.AVAILABLE_DEFAULTS:
+            useDefault = forceUseDefault or super().__getattribute__(
+                "useBackendDefaults"
+            )
+            if (
+                useDefault
+                and not value
+                and super().__getattribute__("backendDefaults")
+                and name in BackendDefaults.AVAILABLE_DEFAULTS
+            ):
                 value = getattr(self.backendDefaults, name)
         except RecursionError:
             pass  # during imports, the backend defaults don't work and would throw an error
@@ -452,22 +516,38 @@ class Backend(models.Model):
 class BackendDefaults(Backend):
     # every field name listed in AVAILABLE_DEFAULTS will automatically appear in the Backend Defaults admin
     # And will automatically be used as default for every Backend
-    AVAILABLE_DEFAULTS = ("suggestionEntityVariable", "suggestionNameVariable", "suggestionAltNameVariable",
-                          "suggestionReversedVariable", "suggestSubjects", "suggestPredicates", "suggestObjects",
-                          "entityNameAndAliasPattern", "entityScorePattern", "predicateNameAndAliasPatternWithoutContext",
-                          "predicateNameAndAliasPatternWithContext", "entityNameAndAliasPatternDefault",
-                          "predicateNameAndAliasPatternWithoutContextDefault", "predicateNameAndAliasPatternWithContextDefault",
-                          "warmupQuery1", "warmupQuery2", "warmupQuery3", "warmupQuery4", "warmupQuery5",
-                          'suggestSubjectsContextInsensitive', 'suggestPredicatesContextInsensitive', 'suggestObjectsContextInsensitive',
-                          'apiToken')
+    AVAILABLE_DEFAULTS = (
+        "suggestionEntityVariable",
+        "suggestionNameVariable",
+        "suggestionAltNameVariable",
+        "suggestionReversedVariable",
+        "suggestSubjects",
+        "suggestPredicates",
+        "suggestObjects",
+        "entityNameAndAliasPattern",
+        "entityScorePattern",
+        "predicateNameAndAliasPatternWithoutContext",
+        "predicateNameAndAliasPatternWithContext",
+        "entityNameAndAliasPatternDefault",
+        "predicateNameAndAliasPatternWithoutContextDefault",
+        "predicateNameAndAliasPatternWithContextDefault",
+        "warmupQuery1",
+        "warmupQuery2",
+        "warmupQuery3",
+        "warmupQuery4",
+        "warmupQuery5",
+        "suggestSubjectsContextInsensitive",
+        "suggestPredicatesContextInsensitive",
+        "suggestObjectsContextInsensitive",
+        "apiToken",
+    )
 
     class Meta:
         verbose_name_plural = "Backend defaults"
 
     def save(self, *args, **kwargs):
         self.name = "Global defaults for all Backends"
-        self.slug = "globaldefaults_" + \
-            str(datetime.datetime.now().timestamp())
+        self.slug = "globaldefaults_" + str(datetime.datetime.now().timestamp())
         self.sortKey = "0"
         self.baseUrl = ""
         self.isDefault = False
@@ -485,14 +565,18 @@ class Link(models.Model):
 class Example(models.Model):
     backend = models.ForeignKey(Backend, on_delete=models.CASCADE)
     name = models.CharField(
-        max_length=100, help_text="Name of this example to show in the user interface")
+        max_length=100, help_text="Name of this example to show in the user interface"
+    )
     query = models.TextField()
     sortKey = models.CharField(
-            max_length=100,
-            default="~",
-            help_text=("Sort key, according to which example queries are ordered lexicographically"
-                       "; default is '~', which is larger than most characters"),
-            verbose_name="Sort key")
+        max_length=100,
+        default="~",
+        help_text=(
+            "Sort key, according to which example queries are ordered lexicographically"
+            "; default is '~', which is larger than most characters"
+        ),
+        verbose_name="Sort key",
+    )
 
     def __str__(self):
         return self.name

--- a/backend/urls.py
+++ b/backend/urls.py
@@ -1,13 +1,19 @@
 from django.urls import re_path
-from django.contrib import admin
 
 from . import views
 
 urlpatterns = [
-    re_path(r'^(?P<backend>[A-Za-z0-9\+@:()%\-_]*)(/(?P<short>[A-Za-z0-9]{6})?)?$',
+    re_path(
+        r"^(?P<backend>[A-Za-z0-9\+@:()%\-_]*)(/(?P<short>[A-Za-z0-9]{6})?)?$",
         views.index,
-        name='index'),
-    re_path(r'^api/share$', views.shareLink, name='shareLink'),
-    re_path(r'^api/warmup/(?P<backend>[^/]+)/(?P<target>[a-zA-Z0-9_-]+)$', views.warmup, name='warmup'),
-    re_path(r'^api/examples/(?P<backend>[^/]+)$', views.examples, name='examples'),
+        name="index",
+    ),
+    re_path(r"^api/share$", views.shareLink, name="shareLink"),
+    re_path(
+        r"^api/warmup/(?P<backend>[^/]+)/(?P<target>[a-zA-Z0-9_-]+)$",
+        views.warmup,
+        name="warmup",
+    ),
+    re_path(r"^api/examples/(?P<backend>[^/]+)$", views.examples, name="examples"),
+    re_path(r"^api/prefixes/(?P<backend>[^/]+)$", views.prefixes, name="prefixes"),
 ]

--- a/backend/views.py
+++ b/backend/views.py
@@ -1,14 +1,12 @@
-from django.core.management.base import CommandError
 from django.http.response import HttpResponse, HttpResponseForbidden
 from django.views.decorators.csrf import csrf_exempt
-from django.contrib.auth.decorators import user_passes_test
 from django.shortcuts import render
 from django.http import JsonResponse
-from django.shortcuts import render
 
 from .models import *
 from backend.management.commands.warmup import Command as WarmupCommand
 from backend.management.commands.examples import Command as ExamplesCommand
+from backend.management.commands.prefixes import Command as PrefixesCommand
 
 import json
 import urllib
@@ -22,8 +20,8 @@ import datetime
 def index(request, backend=None, short=None):
     """
 
-        Index view - shows the UI with all available backends
-        If no preferred backend is set this view choses the default from the database
+    Index view - shows the UI with all available backends
+    If no preferred backend is set this view choses the default from the database
 
     """
     activeBackend = None
@@ -31,13 +29,12 @@ def index(request, backend=None, short=None):
     prefill = None
     noSlugMode = False
 
-    if request.POST.get('whitespaces', False):
-        request.session['logParsing'] = request.POST.get('logParsing', False)
-        request.session['logRequests'] = request.POST.get('logRequests', False)
-        request.session['logSuggestions'] = request.POST.get(
-            'logSuggestions', False)
-        request.session['logOther'] = request.POST.get('logOther', False)
-        request.session['whitespaces'] = request.POST['whitespaces']
+    if request.POST.get("whitespaces", False):
+        request.session["logParsing"] = request.POST.get("logParsing", False)
+        request.session["logRequests"] = request.POST.get("logRequests", False)
+        request.session["logSuggestions"] = request.POST.get("logSuggestions", False)
+        request.session["logOther"] = request.POST.get("logOther", False)
+        request.session["whitespaces"] = request.POST["whitespaces"]
 
     # if a backend is given try to activate it
     if backend:
@@ -56,27 +53,28 @@ def index(request, backend=None, short=None):
                     break
 
         if activeBackend is None:
-            return redirect('/')
+            return redirect("/")
 
     # if no backend is given activate the last one or a default with no-slug mode
     else:
         # go to the last active backend if set
-        if request.session.get('backend', False):
-            activeBackend = Backend.objects.filter(pk=request.session['backend']).first()
+        if request.session.get("backend", False):
+            activeBackend = Backend.objects.filter(
+                pk=request.session["backend"]
+            ).first()
         # find a default backend
         else:
-            activeBackend = Backend.objects.order_by('-isDefault').first()
+            activeBackend = Backend.objects.order_by("-isDefault").first()
 
         if activeBackend is not None:
             if activeBackend.isNoSlugMode:
                 noSlugMode = True
             else:
-                return redirect('/' + activeBackend.slugify())
+                return redirect("/" + activeBackend.slugify())
 
     if activeBackend is not None:
-
         # safe to session
-        request.session['backend'] = activeBackend.pk
+        request.session["backend"] = activeBackend.pk
 
         # Get examples ordered by `sortKey`.
         examples = Example.objects.filter(backend=activeBackend).order_by("sortKey")
@@ -89,59 +87,70 @@ def index(request, backend=None, short=None):
             # if no valid link, then redirect to main backend route
             if activeBackend is not None:
                 if activeBackend.isNoSlugMode:
-                    return redirect('/')
+                    return redirect("/")
                 else:
-                    return redirect('/' + activeBackend.slugify())
+                    return redirect("/" + activeBackend.slugify())
             else:
-                return redirect('/')
+                return redirect("/")
 
         prefill = link.content
     elif request.GET.get("query") is not None:
         prefill = request.GET["query"]
 
     return render(
-        request, 'index.html', {
-            'backend': activeBackend,
-            'noSlugMode': noSlugMode,
-            'prefixes': json.dumps(activeBackend.availablePrefixes) if activeBackend else '{}',
-            'backends': Backend.objects.all(),
-            'examples': examples,
-            'prefill': prefill
-        })
+        request,
+        "index.html",
+        {
+            "backend": activeBackend,
+            "noSlugMode": noSlugMode,
+            "prefixes": json.dumps(activeBackend.availablePrefixes)
+            if activeBackend
+            else "{}",
+            "backends": Backend.objects.all(),
+            "examples": examples,
+            "prefixes": Backend.suggestedPrefixes,
+            "prefill": prefill,
+        },
+    )
 
 
 @csrf_exempt
 def shareLink(request):
     """
-        Generate a sharing link
+    Generate a sharing link
     """
 
-    if request.GET.get('cleanup') != 'true':
-        content = request.POST.get('content')
+    if request.GET.get("cleanup") != "true":
+        content = request.POST.get("content")
         link = Link.objects.filter(content=content).first()
         if not link:
             # space for 56.800.235.584 unique queries in history
             # asuming that one query is about 500 Bytes these are ~ 28 TB of history data
             # asuming that one query is about 1000 Bytes these are ~ 56 TB of history data
-            identifier = ''.join(
-                random.choice(string.ascii_lowercase + string.ascii_uppercase +
-                              string.digits) for _ in range(6))
+            identifier = "".join(
+                random.choice(
+                    string.ascii_lowercase + string.ascii_uppercase + string.digits
+                )
+                for _ in range(6)
+            )
             while Link.objects.filter(identifier=identifier).exists():
-                identifier = ''.join(
-                    random.choice(string.ascii_lowercase + string.ascii_uppercase +
-                                  string.digits) for _ in range(6))
+                identifier = "".join(
+                    random.choice(
+                        string.ascii_lowercase + string.ascii_uppercase + string.digits
+                    )
+                    for _ in range(6)
+                )
 
-            link = Link.objects.create(
-                identifier=identifier, content=content)
+            link = Link.objects.create(identifier=identifier, content=content)
 
         queryString = urllib.parse.urlencode({"query": content})
 
-        return JsonResponse({'link': link.identifier, "queryString": queryString})
+        return JsonResponse({"link": link.identifier, "queryString": queryString})
 
     else:
         if request.user.is_superuser:
             Link.objects.all().delete()
-        return redirect('/')
+        return redirect("/")
 
 
 # Handle "warmup" request.
@@ -167,30 +176,37 @@ def warmup(request, backend, target):
     try:
         tsv = command.handle(returnLog=True, backend=[backend], target=target)
     except Exception as e:
-        return JsonResponse({"status":"error", "message": str(e)})
+        return JsonResponse({"status": "error", "message": str(e)})
     return HttpResponse(tsv, content_type="text/tab-separated-values")
     # return JsonResponse({"status":"ok", "log": log})
 
-# Handle "examples" request, for example:
-#
-# With the URL https://qlever.cs.uni-freiburg.de/api/examples/wikidata
-#
-# this function is called with backend = "wikidata".
+
+# Handle API request like https://qlever.cs.uni-freiburg.de/api/examples/wikidata
 def examples(request, backend):
-    print_to_log(f"Call of \"examples\" in views.py with backend = \"{backend}\"")
+    print_to_log(f'Call of "examples" in views.py with backend = "{backend}"')
     command = ExamplesCommand()
     try:
-        tsv = command.handle(returnLog=True, slug=[backend])
+        examples_tsv = command.handle(returnLog=True, slug=[backend])
     except Exception as e:
         return HttpResponse("Error: " + str(e), status=500)
     return HttpResponse(tsv, content_type="text/tab-separated-values")
 
 
+# Handle API request like https://qlever.cs.uni-freiburg.de/api/prefixes/wikidata
+def prefixes(request, backend):
+    print_to_log(f'Call of "prefixes" in views.py with backend = "{backend}"')
+    command = PrefixesCommand()
+    try:
+        prefixes_text = command.handle(returnLog=True, slug=[backend])
+    except Exception as e:
+        return HttpResponse("Error: " + str(e), status=500)
+    return HttpResponse(prefixes_text, content_type="text/plain")
+
+
 # Helpers
 def print_to_log(msg, output=print):
     """
-        Helper to log things that happen during the process
+    Helper to log things that happen during the process
     """
-    logMsg = datetime.datetime.now().strftime('%d.%m.%Y %H:%M:%S') + ' ' + str(
-        msg)
+    logMsg = datetime.datetime.now().strftime("%d.%m.%Y %H:%M:%S") + " " + str(msg)
     output(logMsg)

--- a/backend/views.py
+++ b/backend/views.py
@@ -108,7 +108,6 @@ def index(request, backend=None, short=None):
             else "{}",
             "backends": Backend.objects.all(),
             "examples": examples,
-            "prefixes": Backend.suggestedPrefixes,
             "prefill": prefill,
         },
     )


### PR DESCRIPTION
The new command can be called in two ways (taking `wikdata` as example backend config):
    
python manage.py prefixes wikidata  [possibly within Docker]
curl -s https://qlever.cs.uni-freiburg.de/api/prefixes/wikidata
    
In both cases, the output is a text with all the prefix definitions defined for the requests backend, with one definition per line, using `PREFIX` (and not `@prefix`) and without trailing dot, sorted alphabetically. For example, for Wikidata:

PREFIX cc: <http://creativecommons.org/ns#>
PREFIX data: <https://www.wikidata.org/wiki/Special:EntityData/>
PREFIX dct: <http://purl.org/dc/terms/>
...
PREFIX wdtn: <http://www.wikidata.org/prop/direct-normalized/>
PREFIX wikibase: <http://wikiba.se/ontology#>
PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
    
On the side, reformat some relevant files using `ruff`.