### PR TITLE
In `Share` dialog, have separate lines for GET and POST

### DIFF
--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -333,13 +333,18 @@ $(document).ready(function () {
 
         // The default media type for the curl command line link is TSV, but for
         // CONSTRUCT queries use Turtle.
-        var mediaType = "text/tab-separated-values";
-        var apiCallCommandLineLabel = "Command line for TSV export (using curl)";
+        var mediaTypePost = "application/sparql-results+json";
+        var mediaTypeGet = "application/qlever-results+json";
         if (queryRewrittenAndNormalizedAndWithEscapedQuotes.match(/CONSTRUCT \{/)) {
-          mediaType = "text/turtle";
-          apiCallCommandLineLabel = apiCallCommandLineLabel.replace(/TSV/, "Turtle");
+          mediaTypePost = "text/turtle";
+          mediaTypeGet = "text/turtle";
         }
-        $("#apiCallCommandLineLabel").html(apiCallCommandLineLabel);
+        var apiCallCommandLineLabelPost =
+          "cURL command line for POST request (" + mediaTypePost + "):";
+        var apiCallCommandLineLabelGet =
+          "cURL command line for GET request (" + mediaTypeGet + "):";
+        $("#apiCallCommandLineLabelPost").html(apiCallCommandLineLabelPost);
+        $("#apiCallCommandLineLabelGet").html(apiCallCommandLineLabelGet);
 
         $(".ok-text").collapse("hide");
         $("#share").modal("show");
@@ -347,10 +352,13 @@ $(document).ready(function () {
         $("#prettyLinkExec").val(baseLocation + result.link + '?exec=true');
         $("#queryStringLink").val(baseLocation + "?" + result.queryString);
         $("#apiCallUrl").val(BASEURL + "?" + result.queryString);
-        $("#apiCallCommandLine").val("curl -s " + BASEURL.replace(/-proxy$/, "")
-          + " -H \"Accept: " + mediaType + "\""
+        $("#apiCallCommandLinePost").val("curl -s " + BASEURL.replace(/-proxy$/, "")
+          + " -H \"Accept: " + mediaTypePost + "\""
           + " -H \"Content-type: application/sparql-query\""
           + " --data \"" + queryRewrittenAndNormalizedAndWithEscapedQuotes + "\"");
+        $("#apiCallCommandLineGet").val("curl -s " + BASEURL.replace(/-proxy$/, "")
+          + " -H \"Accept: " + mediaTypeGet + "\""
+          + " --data-urlencode \"query=" + queryRewrittenAndNormalizedAndWithEscapedQuotes + "\"");
         $("#queryStringUnescaped").val(queryRewrittenAndNormalizedAndWithEscapedQuotes);
       }
     } catch (error) {

--- a/backend/templates/partials/modals/share.html
+++ b/backend/templates/partials/modals/share.html
@@ -69,9 +69,26 @@
           </div>
           <br>
           <div>
-            <label id="apiCallCommandLineLabel">Command line for TSV export (using curl)</label>
+            <label id="apiCallCommandLineLabelPost">Command line for POST query
+              using curl (%MEDIA_TYPE%)</label>
             <div class="input-group">
-              <input type="text" id="apiCallCommandLine" class="form-control" readonly>
+              <input type="text" id="apiCallCommandLinePost" class="form-control" readonly>
+              <span class="input-group-btn">
+                <button class="btn btn-default copy-clipboard-button">
+                  <i class="glyphicon glyphicon-copy"></i> Copy
+                </button>
+              </span>
+            </div>
+            <div class="ok-text collapse">
+              <i class="glyphicon glyphicon-ok"></i> Copied URL to clipboard
+            </div>
+          </div>
+          <br>
+          <div>
+            <label id="apiCallCommandLineLabelGet">Command line for GET query
+              using curl (%MEDIA_TYPE%)</label>
+            <div class="input-group">
+              <input type="text" id="apiCallCommandLineGet" class="form-control" readonly>
               <span class="input-group-btn">
                 <button class="btn btn-default copy-clipboard-button">
                   <i class="glyphicon glyphicon-copy"></i> Copy


### PR DESCRIPTION
For SELECT queries, request media type `application/sparql-results+json` for POST queries and `application/qlever-results+json` for POST queries. For CONSTRUCT queries, request media type `text/turtle` for both. 