### PR TITLE
Fix operation type detection

### DIFF
--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -592,7 +592,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
     default:
       console.log("Unknown operation type");
       disp = "<h4><strong>Error processing operation</strong></h4>";
-      disp += "Could not determine operation type (Query or Update). This is most likely not valid SPARQL. Please <a href='https://github.com/ad-freiburg/qlever-ui/issues/new'>report</a> this operation to us.";
+      disp += "Could not determine operation type (Query or Update). This is most likely not valid SPARQL. Please <a href='https://github.com/ad-freiburg/qlever-ui/issues/new'>report</a> this if you belive it is an error.";
       displayInErrorBlock(disp);
       setErrorIndicator(element);
       removeRunningIndicator(element);

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -626,7 +626,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       return;
     }
     if (operationType === "Unknown" && Array.isArray(result["warnings"])) {
-      result["warnings"].push("Could not determine operation type, assuming query.");
+      result["warnings"].push("Could not determine operation type, defaulting to \"query\"");
     }
     if (result["warnings"].length > 0) { displayWarning(result); }
 

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -521,10 +521,11 @@ function createWebSocketForQuery(queryId, startTimeStamp, query) {
 function determineOperationType(operation) {
   // Strip all PREFIX, BASE and WITH statements from the beginning of the query
   const strippedOp = operation
-      .trim()
-      .replace(/BASE\s+<[^<]*>\s*/gi, "")
-      .replace(/PREFIX\s+\w+:\s+<[^<]*>\s*/gi, "")
-      .replace(/WITH\s+((<[^<]*>)|(\w*:\w*))\s*/gi, "");
+      .replaceAll(/BASE\s+<[^<]*>\s*/gi, "")
+      .replaceAll(/PREFIX\s+\w*:\s+<[^<]*>\s*/gi, "")
+      .replaceAll(/WITH\s+((<[^<]*>)|(\w*:\w*))\s*/gi, "")
+      .replaceAll(/^\s*#.*/gmi, "")
+      .trim();
   const words = strippedOp.split(/\s+/).map(word => word.toUpperCase())
   // Determine the query type based on the first keywords
   switch (words[0]) {

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -521,10 +521,10 @@ function createWebSocketForQuery(queryId, startTimeStamp, query) {
 function determineOperationType(operation) {
   // Strip all PREFIX, BASE and WITH statements from the beginning of the query
   const strippedOp = operation
-      .replaceAll(/BASE\s+<[^<]*>\s*/gi, "")
-      .replaceAll(/PREFIX\s+\w*:\s+<[^<]*>\s*/gi, "")
-      .replaceAll(/WITH\s+((<[^<]*>)|(\w*:\w*))\s*/gi, "")
-      .replaceAll(/^\s*#.*/gmi, "")
+      .replaceAll(/BASE\s+<[^<]*?>\s*/gi, "")
+      .replaceAll(/PREFIX\s+\w*:\s+<[^<]*?>\s*/gi, "")
+      .replaceAll(/WITH\s+((<[^<]*?>)|(\w*?:\w*?))\s*/gi, "")
+      .replaceAll(/^\s*#.*$/gmi, "")
       .trim();
   const words = strippedOp.split(/\s+/).map(word => word.toUpperCase())
   // Determine the query type based on the first keywords

--- a/backend/templates/partials/head.html
+++ b/backend/templates/partials/head.html
@@ -74,8 +74,9 @@
 
   <!-- WASM formatter -->
   <script type="module">
-    import { format } from "{% static '/wasm/formatter/index.js' %}";
+    import { format, determineOperationType } from "{% static '/wasm/formatter/index.js' %}";
     window.format = format;
+    window.determineOperationType = determineOperationType;
   </script>
 
   <!-- Our own JavaScript code for this demo -->

--- a/formatter/index.js
+++ b/formatter/index.js
@@ -1,4 +1,4 @@
-import init, { format_raw } from 'qlue-ls';
+import init, { format_raw, determine_operation_type } from 'qlue-ls';
 import wasmModule from 'qlue-ls/qlue_ls_bg.wasm'
 
 console.info("Loading WebAssembly module...")
@@ -11,4 +11,8 @@ function format(text) {
 	return format_raw(text);
 }
 
-export { format }
+function determineOperationType(text) {
+	return determine_operation_type(text);
+}
+
+export { format, determineOperationType }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-wasm": "^6.2.2",
-        "qlue-ls": "npm:qlue-ls-web@~0.3.5",
+        "qlue-ls": "npm:qlue-ls-web@~0.4.0",
         "rollup": "^4.26.0"
       }
     },
@@ -114,9 +114,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.32.1.tgz",
-      "integrity": "sha512-/pqA4DmqyCm8u5YIDzIdlLcEmuvxb0v8fZdFhVMszSpDTgbQKdw3/mB3eMUHIbubtJ6F9j+LtmyCnHTEqIHyzA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
+      "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
       "cpu": [
         "arm"
       ],
@@ -127,9 +127,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.32.1.tgz",
-      "integrity": "sha512-If3PDskT77q7zgqVqYuj7WG3WC08G1kwXGVFi9Jr8nY6eHucREHkfpX79c0ACAjLj3QIWKPJR7w4i+f5EdLH5Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
+      "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
       "cpu": [
         "arm64"
       ],
@@ -140,9 +140,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.32.1.tgz",
-      "integrity": "sha512-zCpKHioQ9KgZToFp5Wvz6zaWbMzYQ2LJHQ+QixDKq52KKrF65ueu6Af4hLlLWHjX1Wf/0G5kSJM9PySW9IrvHA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
+      "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
       "cpu": [
         "arm64"
       ],
@@ -153,9 +153,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.32.1.tgz",
-      "integrity": "sha512-sFvF+t2+TyUo/ZQqUcifrJIgznx58oFZbdHS9TvHq3xhPVL9nOp+yZ6LKrO9GWTP+6DbFtoyLDbjTpR62Mbr3Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
+      "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
       "cpu": [
         "x64"
       ],
@@ -166,9 +166,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.32.1.tgz",
-      "integrity": "sha512-NbOa+7InvMWRcY9RG+B6kKIMD/FsnQPH0MWUvDlQB1iXnF/UcKSudCXZtv4lW+C276g3w5AxPbfry5rSYvyeYA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
+      "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
       "cpu": [
         "arm64"
       ],
@@ -179,9 +179,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.32.1.tgz",
-      "integrity": "sha512-JRBRmwvHPXR881j2xjry8HZ86wIPK2CcDw0EXchE1UgU0ubWp9nvlT7cZYKc6bkypBt745b4bglf3+xJ7hXWWw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
+      "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
       "cpu": [
         "x64"
       ],
@@ -192,9 +192,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.32.1.tgz",
-      "integrity": "sha512-PKvszb+9o/vVdUzCCjL0sKHukEQV39tD3fepXxYrHE3sTKrRdCydI7uldRLbjLmDA3TFDmh418XH19NOsDRH8g==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
+      "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
       "cpu": [
         "arm"
       ],
@@ -205,9 +205,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.32.1.tgz",
-      "integrity": "sha512-9WHEMV6Y89eL606ReYowXuGF1Yb2vwfKWKdD1A5h+OYnPZSJvxbEjxTRKPgi7tkP2DSnW0YLab1ooy+i/FQp/Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
+      "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
       "cpu": [
         "arm"
       ],
@@ -218,9 +218,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.32.1.tgz",
-      "integrity": "sha512-tZWc9iEt5fGJ1CL2LRPw8OttkCBDs+D8D3oEM8mH8S1ICZCtFJhD7DZ3XMGM8kpqHvhGUTvNUYVDnmkj4BDXnw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
+      "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
       "cpu": [
         "arm64"
       ],
@@ -231,9 +231,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.32.1.tgz",
-      "integrity": "sha512-FTYc2YoTWUsBz5GTTgGkRYYJ5NGJIi/rCY4oK/I8aKowx1ToXeoVVbIE4LGAjsauvlhjfl0MYacxClLld1VrOw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
+      "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
       "cpu": [
         "arm64"
       ],
@@ -244,9 +244,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.32.1.tgz",
-      "integrity": "sha512-F51qLdOtpS6P1zJVRzYM0v6MrBNypyPEN1GfMiz0gPu9jN8ScGaEFIZQwteSsGKg799oR5EaP7+B2jHgL+d+Kw==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
+      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
       "cpu": [
         "loong64"
       ],
@@ -257,9 +257,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.1.tgz",
-      "integrity": "sha512-wO0WkfSppfX4YFm5KhdCCpnpGbtgQNj/tgvYzrVYFKDpven8w2N6Gg5nB6w+wAMO3AIfSTWeTjfVe+uZ23zAlg==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
+      "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
       "cpu": [
         "ppc64"
       ],
@@ -270,9 +270,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.1.tgz",
-      "integrity": "sha512-iWswS9cIXfJO1MFYtI/4jjlrGb/V58oMu4dYJIKnR5UIwbkzR0PJ09O0PDZT0oJ3LYWXBSWahNf/Mjo6i1E5/g==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
+      "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
       "cpu": [
         "riscv64"
       ],
@@ -283,9 +283,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.32.1.tgz",
-      "integrity": "sha512-RKt8NI9tebzmEthMnfVgG3i/XeECkMPS+ibVZjZ6mNekpbbUmkNWuIN2yHsb/mBPyZke4nlI4YqIdFPgKuoyQQ==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
+      "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
       "cpu": [
         "s390x"
       ],
@@ -296,9 +296,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.32.1.tgz",
-      "integrity": "sha512-WQFLZ9c42ECqEjwg/GHHsouij3pzLXkFdz0UxHa/0OM12LzvX7DzedlY0SIEly2v18YZLRhCRoHZDxbBSWoGYg==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
+      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
       "cpu": [
         "x64"
       ],
@@ -309,9 +309,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.32.1.tgz",
-      "integrity": "sha512-BLoiyHDOWoS3uccNSADMza6V6vCNiphi94tQlVIL5de+r6r/CCQuNnerf+1g2mnk2b6edp5dk0nhdZ7aEjOBsA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
+      "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
       "cpu": [
         "x64"
       ],
@@ -322,9 +322,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.32.1.tgz",
-      "integrity": "sha512-w2l3UnlgYTNNU+Z6wOR8YdaioqfEnwPjIsJ66KxKAf0p+AuL2FHeTX6qvM+p/Ue3XPBVNyVSfCrfZiQh7vZHLQ==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
+      "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
       "cpu": [
         "arm64"
       ],
@@ -335,9 +335,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.32.1.tgz",
-      "integrity": "sha512-Am9H+TGLomPGkBnaPWie4F3x+yQ2rr4Bk2jpwy+iV+Gel9jLAu/KqT8k3X4jxFPW6Zf8OMnehyutsd+eHoq1WQ==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
+      "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
       "cpu": [
         "ia32"
       ],
@@ -348,9 +348,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.32.1.tgz",
-      "integrity": "sha512-ar80GhdZb4DgmW3myIS9nRFYcpJRSME8iqWgzH2i44u+IdrzmiXVxeFnExQ5v4JYUSpg94bWjevMG8JHf1Da5Q==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
+      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
       "cpu": [
         "x64"
       ],
@@ -501,9 +501,9 @@
     },
     "node_modules/qlue-ls": {
       "name": "qlue-ls-web",
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/qlue-ls-web/-/qlue-ls-web-0.3.5.tgz",
-      "integrity": "sha512-m+CwWMVu8XFpIruu8pwyFHnYolaXCncUT1pjBo35bkrtbr2JIlldcMm0/yFULU0Tlz349YoTz/2plHKH99P6wQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/qlue-ls-web/-/qlue-ls-web-0.4.0.tgz",
+      "integrity": "sha512-KogeECAgw09c9SVkUJKwcKy7ys1MFVbtVa63gKghY+76FC6QM6QB14HN2Y2m5ufwWdoRkzZ8LzGglkMOTbdEzg==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/resolve": {
@@ -527,9 +527,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.32.1.tgz",
-      "integrity": "sha512-z+aeEsOeEa3mEbS1Tjl6sAZ8NE3+AalQz1RJGj81M+fizusbdDMoEJwdJNHfaB40Scr4qNu+welOfes7maKonA==",
+      "version": "4.34.8",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
+      "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -542,25 +542,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.32.1",
-        "@rollup/rollup-android-arm64": "4.32.1",
-        "@rollup/rollup-darwin-arm64": "4.32.1",
-        "@rollup/rollup-darwin-x64": "4.32.1",
-        "@rollup/rollup-freebsd-arm64": "4.32.1",
-        "@rollup/rollup-freebsd-x64": "4.32.1",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.32.1",
-        "@rollup/rollup-linux-arm-musleabihf": "4.32.1",
-        "@rollup/rollup-linux-arm64-gnu": "4.32.1",
-        "@rollup/rollup-linux-arm64-musl": "4.32.1",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.32.1",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.32.1",
-        "@rollup/rollup-linux-riscv64-gnu": "4.32.1",
-        "@rollup/rollup-linux-s390x-gnu": "4.32.1",
-        "@rollup/rollup-linux-x64-gnu": "4.32.1",
-        "@rollup/rollup-linux-x64-musl": "4.32.1",
-        "@rollup/rollup-win32-arm64-msvc": "4.32.1",
-        "@rollup/rollup-win32-ia32-msvc": "4.32.1",
-        "@rollup/rollup-win32-x64-msvc": "4.32.1",
+        "@rollup/rollup-android-arm-eabi": "4.34.8",
+        "@rollup/rollup-android-arm64": "4.34.8",
+        "@rollup/rollup-darwin-arm64": "4.34.8",
+        "@rollup/rollup-darwin-x64": "4.34.8",
+        "@rollup/rollup-freebsd-arm64": "4.34.8",
+        "@rollup/rollup-freebsd-x64": "4.34.8",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
+        "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
+        "@rollup/rollup-linux-arm64-gnu": "4.34.8",
+        "@rollup/rollup-linux-arm64-musl": "4.34.8",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
+        "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
+        "@rollup/rollup-linux-s390x-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-gnu": "4.34.8",
+        "@rollup/rollup-linux-x64-musl": "4.34.8",
+        "@rollup/rollup-win32-arm64-msvc": "4.34.8",
+        "@rollup/rollup-win32-ia32-msvc": "4.34.8",
+        "@rollup/rollup-win32-x64-msvc": "4.34.8",
         "fsevents": "~2.3.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-wasm": "^6.2.2",
-    "qlue-ls": "npm:qlue-ls-web@~0.3.5",
+    "qlue-ls": "npm:qlue-ls-web@~0.4.0",
     "rollup": "^4.26.0"
   }
 }


### PR DESCRIPTION
PR #126 introduced an automatic detection whether the operation is `query` or `update`. This was done via regexes and not correct in all cases. This is now fixed by using `qlue-ls` for parsing (and defaulting to type `query` when the parser could not determine the type).

Resolves #137. Resolves #138. Resolves ad-freiburg/qlever#1838. Resolves #140.