### PR TITLE
Support chained updates in the UI

### DIFF
--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -96,7 +96,7 @@ async function fetchQleverBackend(params, additionalHeaders = {}) {
 //
 // NOTE: A click on "Analysis" will show the runtime information from the last
 // query. See runtimeInfoForTreant in qleverUI.js.
-function appendRuntimeInformation(runtime_info, query, time, queryUpdate, noop = false) {
+function appendRuntimeInformation(runtime_info, query, time, queryUpdate, isNoop = false) {
   // Backwards compatability hack in case the info on the execution tree is
   // not in a separate "query_execution_tree" element yet.
   if (runtime_info["query_execution_tree"] === undefined) {
@@ -122,7 +122,7 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate, noop =
       timeStamp: queryUpdate.updateTimeStamp,
       runtime_info: runtime_info,
       query: query,
-      noop: noop,
+      isNoop: isNoop,
     });
     if (request_log.size > 10) {
       // Note: `keys().next()` is the key that was inserted first.

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -805,13 +805,13 @@ function displayError(response, queryId = undefined) {
   }
 }
 
-function displayWarning(result) {
-  console.warn('QLever returned warnings while processing request', result);
+function displayWarnings(warnings) {
+  console.warn('QLever returned warnings while processing request', warnings);
 
-  disp = "<h3>Warnings:</h3><ul>";
-  $(result['warnings']).each((el) => {
-    disp += '<li>' + result['warnings'][el] + '</li>';
-  })
+  let disp = "<h3>Warnings:</h3><ul>";
+  warnings.forEach(warning => {
+    disp += '<li>' + warning + '</li>';
+  });
   $('#warningReason').html(disp + '</ul>');
   $('#warningBlock').show();
 }

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -808,7 +808,7 @@ function displayError(response, queryId = undefined) {
   }
 }
 
-function displayWarnings(warnings) {
+function displayWarningsIfPresent(warnings) {
   if (warnings.length === 0) {
     return;
   }

--- a/backend/static/js/helper.js
+++ b/backend/static/js/helper.js
@@ -96,7 +96,7 @@ async function fetchQleverBackend(params, additionalHeaders = {}) {
 //
 // NOTE: A click on "Analysis" will show the runtime information from the last
 // query. See runtimeInfoForTreant in qleverUI.js.
-function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
+function appendRuntimeInformation(runtime_info, query, time, queryUpdate, noop = false) {
   // Backwards compatability hack in case the info on the execution tree is
   // not in a separate "query_execution_tree" element yet.
   if (runtime_info["query_execution_tree"] === undefined) {
@@ -110,8 +110,10 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     runtime_info["meta"]["total_time_computing"] =
         parseInt(time["computeResult"].toString().replace(/ms/, ""), 10);
   }
-  runtime_info["meta"]["total_time"] =
-    parseInt(time["total"].toString().replace(/ms/, ""), 10);
+  if ("total" in time) {
+    runtime_info["meta"]["total_time"] =
+        parseInt(time["total"].toString().replace(/ms/, ""), 10);
+  }
 
   const previousTimeStamp = request_log.get(queryUpdate.queryId)?.timeStamp || Number.MIN_VALUE;
   // If newer runtime info for existing query or new query.
@@ -119,7 +121,8 @@ function appendRuntimeInformation(runtime_info, query, time, queryUpdate) {
     request_log.set(queryUpdate.queryId, {
       timeStamp: queryUpdate.updateTimeStamp,
       runtime_info: runtime_info,
-      query: query
+      query: query,
+      noop: noop,
     });
     if (request_log.size > 10) {
       // Note: `keys().next()` is the key that was inserted first.
@@ -806,6 +809,10 @@ function displayError(response, queryId = undefined) {
 }
 
 function displayWarnings(warnings) {
+  if (warnings.length === 0) {
+    return;
+  }
+
   console.warn('QLever returned warnings while processing request', warnings);
 
   let disp = "<h3>Warnings:</h3><ul>";

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -904,15 +904,15 @@ function renderRuntimeInformationToDom(entry = undefined) {
   const {
     runtime_info,
     query,
-    noop
+    isNoop
   } = entry || Array.from(request_log.values()).pop();
 
   // When the last operation was a noop, no runtime info is available.
-  if (noop) {
+  if (isNoop) {
     $("#result-query").text("");
     $("#meta-info").text("");
     const resultTree = $("#result-tree");
-    resultTree.text("No query analysis available, because the operation has no effect and was optimized out.");
+    resultTree.text("No query analysis available, because the operation has no effect and was optimized out");
     resultTree.css("color", "green");
     return;
   }

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -633,7 +633,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
         }
         // Collect warnings from all updates and display the unique ones.
         const uniqueWarnings = [...new Set(result.map(result => result["warnings"]).flat())];
-        displayWarnings(uniqueWarnings);
+        displayWarningsIfPresent(uniqueWarnings);
 
         const operationMetadata = result.map(result => result["delta-triples"].operation);
         $('#answerBlock, #infoBlock, #errorBlock').hide();
@@ -675,7 +675,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
         }
       case "Query":
         // Display warnings.
-        displayWarnings(result["warnings"]);
+        displayWarningsIfPresent(result["warnings"]);
 
         // Show some statistics (on top of the table).
         //

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -617,7 +617,7 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
   headers["Query-Id"] = queryId;
 
   try {
-    const result = await fetchQleverBackend(params, headers);
+    let result = await fetchQleverBackend(params, headers);
     
     log('Evaluating and displaying results...', 'other');
 
@@ -625,12 +625,12 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
       displayError(result, queryId);
       return;
     }
-    if (operationType === "Unknown" && Array.isArray(result["warnings"])) {
-      result["warnings"].push("Could not determine operation type, defaulting to \"query\"");
-    }
 
     switch (operationType) {
       case "Update":
+        if (!Array.isArray(result)) {
+          result = [result];
+        }
         // Collect warnings from all updates and display the unique ones.
         const uniqueWarnings = [...new Set(result.map(result => result["warnings"]).flat())];
         displayWarnings(uniqueWarnings);
@@ -663,6 +663,9 @@ async function processQuery(sendLimit=0, element=$("#exebtn")) {
         break
         // The operation type wasn't detected. It was most likely syntactically invalid and resulted in an error while parsing. Display the result anyway in case some valid queries were not identified.
       case "Unknown":
+        if (Array.isArray(result["warnings"])) {
+          result["warnings"].push("Could not determine operation type, defaulting to \"query\"");
+        }
       case "Query":
         // Display warnings.
         displayWarnings(result["warnings"]);


### PR DESCRIPTION
For multiple updates, this shows aggregated statistics (also saying how many updates were aggregated). The query response used to be a JSON object and is now an array of JSON objects. For "Analysis", the last update in a chain is shown.

This should be merged before ad-freiburg/qlever#1883, which implemented chained updates in QLever.