### PR TITLE
Show buttons for privileged commands in main panel

### DIFF
--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -93,10 +93,6 @@ th { color: #82B36F; white-space: nowrap; }
 	display: none;
 }
 
-#dynamicSuggestions {
-	margin-top: 10px;
-}
-
 @media (min-width: 990px) {
 	.d,
 	#help,
@@ -111,6 +107,17 @@ th { color: #82B36F; white-space: nowrap; }
 
 .pb-1 {
     padding-bottom: 1em;
+}
+
+.btn-group-flex {
+    display: flex;
+    flex-wrap: wrap;
+}
+.btn-group-flex .btn {
+    flex: 1;
+}
+.btn-group-flex .btn-group {
+    flex: 1;
 }
 
 /**

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -93,14 +93,6 @@ th { color: #82B36F; white-space: nowrap; }
 	display: none;
 }
 
-.buttonFlex {
-  display: flex;
-  align-items: end;
-  flex-wrap: wrap;
-}
-
-.buttonFlex>button, .buttonFlex>.btn-group { margin-right: 5px; }
-
 #dynamicSuggestions {
 	margin-top: 10px;
 }
@@ -115,6 +107,10 @@ th { color: #82B36F; white-space: nowrap; }
 	#dynamicSuggestions {
 		margin-top: 0px;
 	}
+}
+
+.pb-1 {
+    padding-bottom: 1em;
 }
 
 /**

--- a/backend/static/css/style.css
+++ b/backend/static/css/style.css
@@ -106,7 +106,7 @@ th { color: #82B36F; white-space: nowrap; }
 }
 
 .pb-1 {
-    padding-bottom: 1em;
+    padding-bottom: 0.5em;
 }
 
 .btn-group-flex {

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -378,9 +378,9 @@ $(document).ready(function () {
 
   function updateBackendCommandVisibility() {
     if (accessToken.val().trim() === "") {
-      $("#backend_commands").css("visibility", "hidden");
+      $("#backend_commands").hide();
     } else {
-      $("#backend_commands").css("visibility", "");
+      $("#backend_commands").show();
     }
   }
 

--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -378,9 +378,9 @@ $(document).ready(function () {
 
   function updateBackendCommandVisibility() {
     if (accessToken.val().trim() === "") {
-      $("#backend_commands").hide();
+      $("#backend_commands").css("visibility", "hidden");
     } else {
-      $("#backend_commands").show();
+      $("#backend_commands").css("visibility", "");
     }
   }
 

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -156,140 +156,157 @@
                   </table>
                 </div>
               </div>
-                <div class="col-lg-4 pb-1">
-                    <div class="btn-group btn-group-flex" role="group">
-                        <!--
-                         The run button. Note: min-width keeps the same width regardless
-                         of the label (Execute, Cancel or Cancelling)
-                       -->
-                        <button id="exebtn" class="btn btn-success btn-block">
-                            <i class="glyphicon glyphicon-refresh"></i> <span>Execute</span>
-                        </button>
-                        <!-- The download buttons -->
-                        <div class="btn-group" role="group">
-                            <button class="btn btn-default btn-block dropdown-toggle" type="button"
-                                    data-toggle="dropdown">
-                                <i class="glyphicon glyphicon-download"></i> Download
-                                <span class="caret"></span>
-                            </button>
-                            <ul class="dropdown-menu">
-                                <li>
-                                    <a class="dropdown-item" id="csvbtn" href="#csv">
-                                        <i class="glyphicon glyphicon-file"></i> Download results as CSV
-                                    </a>
-                                </li>
-                                <li>
-                                    <a class="dropdown-item" id="tsvbtn" href="#tsv">
-                                        <i class="glyphicon glyphicon-file"></i> Download results as TSV
-                                    </a>
-                                </li>
-                            </ul>
-                        </div>
-                        <!-- The share button -->
-                        <button id="sharebtn" class="btn btn-default">
-                            <i class="glyphicon glyphicon-share-alt"></i> Share
-                        </button>
-                    </div>
-                </div>
+                <div class="col-lg-9 col-xs-12">
+                    <div class="row">
 
-                <div class="col-lg-4 col-sm-8 pb-1">
-                    <div class="btn-group btn-group-flex" role="group" id="backend_commands" style="visibility: hidden">
-                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-delta-triples', this)">
-                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
-                        </button>
-                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
-                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
-                        </button>
-                    </div>
-                </div>
-
-                <div class="col-lg-3 col-lg-offset-1 col-sm-4 pb-1">
-                    <select class="form-control" id="dynamicSuggestions">
-                        <option value="0" {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
-                            1. Syntax & keywords only
-                        </option>
-                        <option value="1" {% if backend.dynamicSuggestions == 1 %}selected="selected"{% endif %}>
-                            2. Context insensitive suggestions
-                        </option>
-                        <option value="2" {% if backend.dynamicSuggestions == 2 %}selected="selected"{% endif %}>
-                            3. Context sensitive suggestions
-                        </option>
-                        <option value="3" {% if backend.dynamicSuggestions == 3 %}selected="selected"{% endif %}>
-                            4. Mixed mode
-                        </option>
-                    </select>
-                </div>
-
-                <div class="col-lg-6 col-sm-8 pb-1">
-                    <!-- The context setting buttons -->
-                    <div class="btn-group btn-group-flex" role="group">
-                        <button id="formatButton" class="btn btn-default">
-                            <i class="glyphicon glyphicon-align-left"></i> Format
-                        </button>
-                        <button class="btn btn-default" onclick="executeBackendCommand('clear-cache', this)">
-                            <i class="glyphicon glyphicon-refresh"></i> Clear cache
-                        </button>
-                        <button class="btn btn-default" onclick="showQueryPlanningTree();">
-                            <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
-                        </button>
-                        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                            <i class="glyphicon glyphicon-align-left"></i> Examples
-                            <span class="caret"></span>
-                        </button>
-                        <ul id="exampleList" class="dropdown-menu">
-                            <div style="padding: 10px 20px;">
-                                <input id="exampleKeywordSearchInput" type="text" placeholder="search for keywords"
-                                       style="width: 100%">
+                        <div class="col-lg-5 col-md-5 col-xs-12 pb-1">
+                            <div class="btn-group btn-group-flex" role="group">
+                                <!--
+                                 The run button. Note: min-width keeps the same width regardless
+                                 of the label (Execute, Cancel or Cancelling)
+                               -->
+                                <button id="exebtn" class="btn btn-success btn-block">
+                                    <i class="glyphicon glyphicon-refresh"></i> <span>Execute</span>
+                                </button>
+                                <!-- The download buttons -->
+                                <div class="btn-group" role="group">
+                                    <button class="btn btn-default btn-block dropdown-toggle" type="button"
+                                            data-toggle="dropdown">
+                                        <i class="glyphicon glyphicon-download"></i> Download
+                                        <span class="caret"></span>
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        <li>
+                                            <a class="dropdown-item" id="csvbtn" href="#csv">
+                                                <i class="glyphicon glyphicon-file"></i> Download results as CSV
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a class="dropdown-item" id="tsvbtn" href="#tsv">
+                                                <i class="glyphicon glyphicon-file"></i> Download results as TSV
+                                            </a>
+                                        </li>
+                                    </ul>
+                                </div>
+                                <!-- The share button -->
+                                <button id="sharebtn" class="btn btn-default">
+                                    <i class="glyphicon glyphicon-share-alt"></i> Share
+                                </button>
                             </div>
-                            <li class="divider"></li>
-                            {% for example in examples %}
-                                <li>
-                                    <a onclick="example=1;editor.setValue(examples[{{ forloop.counter0 }}]);editor.focus()">
-                                        {% if request.user.is_authenticated %}
-                                            <span onclick="window.open('/admin/backend/example/{{ example.pk }}/change/','_blank');"
-                                                  style="float: right;">
+                        </div>
+
+                        <div class="col-lg-7 col-md-7 col-xs-12 pb-1">
+                            <!-- The context setting buttons -->
+                            <div class="btn-group btn-group-flex" role="group">
+                                <button id="formatButton" class="btn btn-default">
+                                    <i class="glyphicon glyphicon-align-left"></i> Format
+                                </button>
+                                <button class="btn btn-default" onclick="executeBackendCommand('clear-cache', this)">
+                                    <i class="glyphicon glyphicon-refresh"></i> Clear cache
+                                </button>
+                                <button class="btn btn-default" onclick="showQueryPlanningTree();">
+                                    <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
+                                </button>
+                                <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                                    <i class="glyphicon glyphicon-align-left"></i> Examples
+                                    <span class="caret"></span>
+                                </button>
+                                <ul id="exampleList" class="dropdown-menu">
+                                    <div style="padding: 10px 20px;">
+                                        <input id="exampleKeywordSearchInput" type="text"
+                                               placeholder="search for keywords"
+                                               style="width: 100%">
+                                    </div>
+                                    <li class="divider"></li>
+                                    {% for example in examples %}
+                                        <li>
+                                            <a onclick="example=1;editor.setValue(examples[{{ forloop.counter0 }}]);editor.focus()">
+                                                {% if request.user.is_authenticated %}
+                                                    <span onclick="window.open('/admin/backend/example/{{ example.pk }}/change/','_blank');"
+                                                          style="float: right;">
                                 <i class="glyphicon glyphicon-pencil"></i>
                               </span>
-                                        {% endif %}
-                                        <span class="example-name"
-                                              style="margin-right: 30px">{{ example.name }}</span>
-                                    </a>
-                                </li>
-                            {% endfor %}
-                            <li id="empty-examples-excuse" style="display: none">
-                                <span style="padding: 3px 20px;">Sorry, no examples found :(</span>
-                            </li>
-                            {% if request.user.is_authenticated %}
-                                <li class="divider"></li>
-                                <li>
-                                    <a onclick="window.open('/admin/backend/example/add/?backend={{ backend.pk }}&query='+encodeURIComponent(editor.getValue()),'_blank');">
-                                        <i class="glyphicon glyphicon-check"></i> Add current query as example
-                                    </a>
-                                </li>
-                                <li>
-                                    <a href="/admin/backend/example/add/?backend={{ backend.pk }}" target="_blank">
-                                        <i class="glyphicon glyphicon-edit"></i> Add new example
-                                    </a>
-                                </li>
-                            {% endif %}
-                        </ul>
+                                                {% endif %}
+                                                <span class="example-name"
+                                                      style="margin-right: 30px">{{ example.name }}</span>
+                                            </a>
+                                        </li>
+                                    {% endfor %}
+                                    <li id="empty-examples-excuse" style="display: none">
+                                        <span style="padding: 3px 20px;">Sorry, no examples found :(</span>
+                                    </li>
+                                    {% if request.user.is_authenticated %}
+                                        <li class="divider"></li>
+                                        <li>
+                                            <a onclick="window.open('/admin/backend/example/add/?backend={{ backend.pk }}&query='+encodeURIComponent(editor.getValue()),'_blank');">
+                                                <i class="glyphicon glyphicon-check"></i> Add current query as example
+                                            </a>
+                                        </li>
+                                        <li>
+                                            <a href="/admin/backend/example/add/?backend={{ backend.pk }}"
+                                               target="_blank">
+                                                <i class="glyphicon glyphicon-edit"></i> Add new example
+                                            </a>
+                                        </li>
+                                    {% endif %}
+                                </ul>
+                            </div>
+                        </div>
+
+                        <div class="col-lg-6 col-md-5 col-xs-12" id="backend_commands" style="display: none">
+                            <div class="btn-group btn-group-flex" role="group">
+                                <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
+                                        onclick="executeBackendCommand('clear-delta-triples', this)">
+                                    <i class="glyphicon glyphicon-refresh"></i> Reset Updates
+                                </button>
+                                <button type="button" id="btnClearCacheComplete" class="btn btn-default"
+                                        onclick="executeBackendCommand('clear-cache-complete', this)"><i
+                                        class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                                </button>
+                            </div>
+                        </div>
+
+                    </div>
+                </div>
+                <div class="col-lg-3 col-xs-12">
+                    <div class="row">
+
+                        <div class="col-lg-12 col-lg-push-0 col-lg-offset-0 col-md-push-4 col-md-offset-4 col-md-4 col-xs-12 pb-1">
+                            <select class="form-control" id="dynamicSuggestions">
+                                <option value="0"
+                                        {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
+                                    1. Syntax & keywords only
+                                </option>
+                                <option value="1"
+                                        {% if backend.dynamicSuggestions == 1 %}selected="selected"{% endif %}>
+                                    2. Context insensitive suggestions
+                                </option>
+                                <option value="2"
+                                        {% if backend.dynamicSuggestions == 2 %}selected="selected"{% endif %}>
+                                    3. Context sensitive suggestions
+                                </option>
+                                <option value="3"
+                                        {% if backend.dynamicSuggestions == 3 %}selected="selected"{% endif %}>
+                                    4. Mixed mode
+                                </option>
+                            </select>
+                        </div>
+
+                        <div class="col-lg-12 col-lg-pull-0 col-md-pull-4 col-md-4 col-xs-12">
+                            <div class="checkbox">
+                                <label>
+                                    <input type="checkbox" id="name_service"> Automatically add names to result
+                                </label>
+                            </div>
+                            <div class="checkbox" style="display: none">
+                                <label>
+                                    <input type="checkbox" id="clear"> Clear the cache before every request
+                                </label>
+                            </div>
+                        </div>
                     </div>
                 </div>
 
-                <div class="col-lg-3 col-lg-offset-3 col-sm-4 pb-1">
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox" id="name_service"> Automatically add names to result
-                        </label>
-                    </div>
-                    <div class="checkbox" style="display: none">
-                        <label>
-                            <input type="checkbox" id="clear"> Clear the cache before every request
-                        </label>
-                    </div>
-                </div>
             </div>
           </div>
 

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -254,16 +254,14 @@
                         </div>
 
                         <div class="col-lg-6 col-md-5 col-xs-12" id="backend_commands" style="display: none">
-                            <div class="btn-group btn-group-flex" role="group">
-                                <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
-                                        onclick="executeBackendCommand('clear-delta-triples', this)">
-                                    <i class="glyphicon glyphicon-refresh"></i> Reset Updates
-                                </button>
-                                <button type="button" id="btnClearCacheComplete" class="btn btn-default"
-                                        onclick="executeBackendCommand('clear-cache-complete', this)"><i
-                                        class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
-                                </button>
-                            </div>
+                            <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
+                                    onclick="executeBackendCommand('clear-delta-triples', this)">
+                                <i class="glyphicon glyphicon-refresh"></i> Reset Updates
+                            </button>
+                            <button type="button" id="btnClearCacheComplete" class="btn btn-default"
+                                    onclick="executeBackendCommand('clear-cache-complete', this)"><i
+                                    class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                            </button>
                         </div>
 
                     </div>

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -156,7 +156,7 @@
                   </table>
                 </div>
               </div>
-                <div class="col-lg-6 pb-1">
+                <div class="col-lg-4 pb-1">
                     <div class="btn-group btn-group-flex" role="group">
                         <!--
                          The run button. Note: min-width keeps the same width regardless
@@ -192,7 +192,20 @@
                     </div>
                 </div>
 
-                <div class="col-sm-6 col-lg-3 pb-1">
+                <div class="col-lg-4 col-sm-8 pb-1">
+                    <div class="btn-group btn-group-flex" role="group" id="backend_commands" style="visibility: hidden">
+                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-delta-triples', this)">
+                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
+                        </button>
+                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
+                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                        </button>
+                    </div>
+                </div>
+
+                <div class="col-lg-3 col-lg-offset-1 col-sm-4 pb-1">
                     <select class="form-control" id="dynamicSuggestions">
                         <option value="0" {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
                             1. Syntax & keywords only
@@ -209,20 +222,7 @@
                     </select>
                 </div>
 
-                <div class="col-sm-6 col-lg-3 pb-1">
-                    <div class="checkbox">
-                        <label>
-                            <input type="checkbox" id="name_service"> Automatically add names to result
-                        </label>
-                    </div>
-                    <div class="checkbox" style="display: none">
-                        <label>
-                            <input type="checkbox" id="clear"> Clear the cache before every request
-                        </label>
-                    </div>
-                </div>
-
-                <div class="col-lg-6 pb-1">
+                <div class="col-lg-6 col-sm-8 pb-1">
                     <!-- The context setting buttons -->
                     <div class="btn-group btn-group-flex" role="group">
                         <button id="formatButton" class="btn btn-default">
@@ -278,16 +278,16 @@
                     </div>
                 </div>
 
-                <div class="col-lg-6">
-                    <div class="btn-group btn-group-flex" role="group" id="backend_commands" style="display: none">
-                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-delta-triples', this)">
-                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
-                        </button>
-                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
-                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
-                        </button>
+                <div class="col-lg-3 col-lg-offset-3 col-sm-4 pb-1">
+                    <div class="checkbox">
+                        <label>
+                            <input type="checkbox" id="name_service"> Automatically add names to result
+                        </label>
+                    </div>
+                    <div class="checkbox" style="display: none">
+                        <label>
+                            <input type="checkbox" id="clear"> Clear the cache before every request
+                        </label>
                     </div>
                 </div>
             </div>

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -93,18 +93,8 @@
                     <tr><th>Default mode:</th><td> {% if backend.dynamicSuggestions == 0 %}1. SPARQL syntax & keywords only{% elif backend.dynamicSuggestions == 1 %}2. SPARQL & context insensitive entities{% else %}3. SPARQL & context sensitive entities{% endif %}</td></tr>
                     <tr>
                         <th>Access Token</th>
-                        <td><input class="form-control" type="text" id="access_token" placeholder="Access Token" style="margin-bottom: 8px"/>
-                            <div id="backend_commands" style="display:none">
-                                <button id="btnClearDeltaTriples" class="btn btn-default"
-                                        onclick="executeBackendCommand('clear-delta-triples', this)" style="margin-bottom: 8px"><i
-                                        class="glyphicon glyphicon-refresh"></i> Clear Delta Triples
-                                </button><br>
-                                <button id="btnClearCacheComplete" class="btn btn-default"
-                                        onclick="executeBackendCommand('clear-cache-complete', this)"><i
-                                        class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
-                                </button>
-                            </div>
-                        </td>
+                        <td><input class="form-control" type="text" id="access_token" placeholder="Access Token"
+                                   style="margin-bottom: 8px"/></td>
                     </tr>
                 </table>
               </div>
@@ -166,10 +156,7 @@
                   </table>
                 </div>
               </div>
-              <div class="col-md-9">
-                  
-                <div class="row">
-                  <div class="col-md-12 buttonFlex">
+                <div class="col-md-4 pb-1">
                     <!--
                       The run button. Note: min-width keeps the same width regardless
                       of the label (Execute, Cancel or Cancelling)
@@ -202,7 +189,9 @@
                     <button id="sharebtn" class="btn btn-default">
                       <i class="glyphicon glyphicon-share-alt"></i> Share
                     </button>
-                    
+                </div>
+                <div class="col-sm-8 col-sm-offset-4 col-md-5 pb-1">
+
                     <!-- The context setting buttons -->
                     <div class="btn-group" role="group" style="margin-left:auto;">
                     <button id="formatButton" class="btn btn-default">
@@ -252,11 +241,9 @@
                           </li>
                         {% endif %}
                       </ul>
-                    </div>
-                  </div>
                 </div>
               </div>
-              <div class="col-md-3">
+                <div class="col-md-3 pb-1">
                 <select class="form-control" id="dynamicSuggestions">
                   <option value="0" {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
                     1. Syntax & keywords only
@@ -273,7 +260,20 @@
                 </select>
              </div>
 
-                <div class="col-md-3 col-md-offset-9">
+                <div class="col-sm-7 col-md-5 col-md-offset-4 pb-1">
+                    <div class="btn-group" role="group" id="backend_commands" style="display:none">
+                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-delta-triples', this)">
+                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
+                        </button>
+                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
+                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                        </button>
+                    </div>
+                </div>
+
+                <div class="col-sm-5 col-md-3 pb-1">
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" id="name_service"> Automatically add names to result

--- a/backend/templates/index.html
+++ b/backend/templates/index.html
@@ -156,124 +156,60 @@
                   </table>
                 </div>
               </div>
-                <div class="col-md-4 pb-1">
-                    <!--
-                      The run button. Note: min-width keeps the same width regardless
-                      of the label (Execute, Cancel or Cancelling)
-                    -->
-                    <button id="exebtn" class="btn btn-success" style="min-width: 7.857em;">
-                      <i class="glyphicon glyphicon-refresh"></i> <span>Execute</span>
-                    </button>
-
-                    <!-- The download buttons -->
-                    <div class="btn-group" role="group">
-                      <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                          <i class="glyphicon glyphicon-download"></i> Download
-                          <span class="caret"></span>
-                      </button>
-                      <ul class="dropdown-menu">
-                        <li>
-                          <a class="dropdown-item" id="csvbtn" href="#csv">
-                            <i class="glyphicon glyphicon-file"></i> Download results as CSV
-                          </a>
-                        </li>
-                        <li>
-                          <a class="dropdown-item" id="tsvbtn" href="#tsv">
-                            <i class="glyphicon glyphicon-file"></i> Download results as TSV
-                          </a>
-                        </li>
-                      </ul>
-                    </div>
-
-                    <!-- The share button -->
-                    <button id="sharebtn" class="btn btn-default">
-                      <i class="glyphicon glyphicon-share-alt"></i> Share
-                    </button>
-                </div>
-                <div class="col-sm-8 col-sm-offset-4 col-md-5 pb-1">
-
-                    <!-- The context setting buttons -->
-                    <div class="btn-group" role="group" style="margin-left:auto;">
-                    <button id="formatButton" class="btn btn-default">
-                      <i class="glyphicon glyphicon-align-left"></i> Format
-                    </button>
-                      <button class="btn btn-default" onclick="executeBackendCommand('clear-cache', this)">
-                        <i class="glyphicon glyphicon-refresh"></i> Clear cache
-                      </button>
-                      <button class="btn btn-default" onclick="showQueryPlanningTree();">
-                        <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
-                      </button>
-                      <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
-                        <i class="glyphicon glyphicon-align-left"></i> Examples
-                        <span class="caret"></span>
-                      </button>
-                      <ul id="exampleList" class="dropdown-menu">
-                        <div style="padding: 10px 20px;">
-                          <input id="exampleKeywordSearchInput" type="text" placeholder="search for keywords" style="width: 100%"> </input>
+                <div class="col-lg-6 pb-1">
+                    <div class="btn-group btn-group-flex" role="group">
+                        <!--
+                         The run button. Note: min-width keeps the same width regardless
+                         of the label (Execute, Cancel or Cancelling)
+                       -->
+                        <button id="exebtn" class="btn btn-success btn-block">
+                            <i class="glyphicon glyphicon-refresh"></i> <span>Execute</span>
+                        </button>
+                        <!-- The download buttons -->
+                        <div class="btn-group" role="group">
+                            <button class="btn btn-default btn-block dropdown-toggle" type="button"
+                                    data-toggle="dropdown">
+                                <i class="glyphicon glyphicon-download"></i> Download
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <a class="dropdown-item" id="csvbtn" href="#csv">
+                                        <i class="glyphicon glyphicon-file"></i> Download results as CSV
+                                    </a>
+                                </li>
+                                <li>
+                                    <a class="dropdown-item" id="tsvbtn" href="#tsv">
+                                        <i class="glyphicon glyphicon-file"></i> Download results as TSV
+                                    </a>
+                                </li>
+                            </ul>
                         </div>
-                        <li class="divider"></li>
-                        {% for example in examples %}
-                          <li>
-                            <a onclick="example=1;editor.setValue(examples[{{ forloop.counter0 }}]);editor.focus()">
-                              {% if request.user.is_authenticated %}
-                              <span onclick="window.open('/admin/backend/example/{{ example.pk }}/change/','_blank');" style="float: right;">
-                                <i class="glyphicon glyphicon-pencil"></i>
-                              </span>
-                              {% endif %}
-                              <span class="example-name" style="margin-right: 30px">{{ example.name }}</span>
-                            </a>
-                          </li>
-                        {% endfor %}
-                        <li id="empty-examples-excuse" style="display: none">
-                              <span style="padding: 3px 20px;">Sorry, no examples found :(</span>
-                        </li>
-                        {% if request.user.is_authenticated %}
-                          <li class="divider"></li>
-                          <li>
-                            <a onclick="window.open('/admin/backend/example/add/?backend={{ backend.pk }}&query='+encodeURIComponent(editor.getValue()),'_blank');">
-                              <i class="glyphicon glyphicon-check"></i> Add current query as example
-                            </a>
-                          </li>
-                          <li>
-                            <a href="/admin/backend/example/add/?backend={{ backend.pk }}" target="_blank">
-                              <i class="glyphicon glyphicon-edit"></i> Add new example
-                            </a>
-                          </li>
-                        {% endif %}
-                      </ul>
-                </div>
-              </div>
-                <div class="col-md-3 pb-1">
-                <select class="form-control" id="dynamicSuggestions">
-                  <option value="0" {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
-                    1. Syntax & keywords only
-                  </option>
-                  <option value="1" {% if backend.dynamicSuggestions == 1 %}selected="selected"{% endif %}>
-                    2. Context insensitive suggestions
-                  </option>
-                  <option value="2" {% if backend.dynamicSuggestions == 2 %}selected="selected"{% endif %}>
-                    3. Context sensitive suggestions
-                  </option>
-                  <option value="3" {% if backend.dynamicSuggestions == 3 %}selected="selected"{% endif %}>
-                    4. Mixed mode
-                  </option>
-                </select>
-             </div>
-
-                <div class="col-sm-7 col-md-5 col-md-offset-4 pb-1">
-                    <div class="btn-group" role="group" id="backend_commands" style="display:none">
-                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-delta-triples', this)">
-                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
-                        </button>
-                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
-                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
-                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                        <!-- The share button -->
+                        <button id="sharebtn" class="btn btn-default">
+                            <i class="glyphicon glyphicon-share-alt"></i> Share
                         </button>
                     </div>
                 </div>
 
-                <div class="col-sm-5 col-md-3 pb-1">
+                <div class="col-sm-6 col-lg-3 pb-1">
+                    <select class="form-control" id="dynamicSuggestions">
+                        <option value="0" {% if backend.dynamicSuggestions == 0 %}selected="selected"{% endif %}>
+                            1. Syntax & keywords only
+                        </option>
+                        <option value="1" {% if backend.dynamicSuggestions == 1 %}selected="selected"{% endif %}>
+                            2. Context insensitive suggestions
+                        </option>
+                        <option value="2" {% if backend.dynamicSuggestions == 2 %}selected="selected"{% endif %}>
+                            3. Context sensitive suggestions
+                        </option>
+                        <option value="3" {% if backend.dynamicSuggestions == 3 %}selected="selected"{% endif %}>
+                            4. Mixed mode
+                        </option>
+                    </select>
+                </div>
+
+                <div class="col-sm-6 col-lg-3 pb-1">
                     <div class="checkbox">
                         <label>
                             <input type="checkbox" id="name_service"> Automatically add names to result
@@ -283,6 +219,75 @@
                         <label>
                             <input type="checkbox" id="clear"> Clear the cache before every request
                         </label>
+                    </div>
+                </div>
+
+                <div class="col-lg-6 pb-1">
+                    <!-- The context setting buttons -->
+                    <div class="btn-group btn-group-flex" role="group">
+                        <button id="formatButton" class="btn btn-default">
+                            <i class="glyphicon glyphicon-align-left"></i> Format
+                        </button>
+                        <button class="btn btn-default" onclick="executeBackendCommand('clear-cache', this)">
+                            <i class="glyphicon glyphicon-refresh"></i> Clear cache
+                        </button>
+                        <button class="btn btn-default" onclick="showQueryPlanningTree();">
+                            <i class="glyphicon glyphicon-object-align-vertical"></i> Analysis
+                        </button>
+                        <button class="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown">
+                            <i class="glyphicon glyphicon-align-left"></i> Examples
+                            <span class="caret"></span>
+                        </button>
+                        <ul id="exampleList" class="dropdown-menu">
+                            <div style="padding: 10px 20px;">
+                                <input id="exampleKeywordSearchInput" type="text" placeholder="search for keywords"
+                                       style="width: 100%">
+                            </div>
+                            <li class="divider"></li>
+                            {% for example in examples %}
+                                <li>
+                                    <a onclick="example=1;editor.setValue(examples[{{ forloop.counter0 }}]);editor.focus()">
+                                        {% if request.user.is_authenticated %}
+                                            <span onclick="window.open('/admin/backend/example/{{ example.pk }}/change/','_blank');"
+                                                  style="float: right;">
+                                <i class="glyphicon glyphicon-pencil"></i>
+                              </span>
+                                        {% endif %}
+                                        <span class="example-name"
+                                              style="margin-right: 30px">{{ example.name }}</span>
+                                    </a>
+                                </li>
+                            {% endfor %}
+                            <li id="empty-examples-excuse" style="display: none">
+                                <span style="padding: 3px 20px;">Sorry, no examples found :(</span>
+                            </li>
+                            {% if request.user.is_authenticated %}
+                                <li class="divider"></li>
+                                <li>
+                                    <a onclick="window.open('/admin/backend/example/add/?backend={{ backend.pk }}&query='+encodeURIComponent(editor.getValue()),'_blank');">
+                                        <i class="glyphicon glyphicon-check"></i> Add current query as example
+                                    </a>
+                                </li>
+                                <li>
+                                    <a href="/admin/backend/example/add/?backend={{ backend.pk }}" target="_blank">
+                                        <i class="glyphicon glyphicon-edit"></i> Add new example
+                                    </a>
+                                </li>
+                            {% endif %}
+                        </ul>
+                    </div>
+                </div>
+
+                <div class="col-lg-6">
+                    <div class="btn-group btn-group-flex" role="group" id="backend_commands" style="display: none">
+                        <button type="button" id="btnClearDeltaTriples" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-delta-triples', this)">
+                            <i class="glyphicon glyphicon-refresh"></i> Reset Updates
+                        </button>
+                        <button type="button" id="btnClearCacheComplete" class="btn btn-default"
+                                onclick="executeBackendCommand('clear-cache-complete', this)"><i
+                                class="glyphicon glyphicon-refresh"></i> Clear Cache (Complete)
+                        </button>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
When a string is entered in the "Access Token" field in the "Backend Information" panel, two buttons for privileged commands appear (one for removing all delta triples and one for clearing the cache completely, including the pinned results). So far, these buttons appeared in the same "Backend Information" panel, which is usually hidden. Now they appear in the row below the usual buttons (for executing the query, downloading the result, etc).

![image](https://github.com/user-attachments/assets/96ee2b88-5ce0-4185-8174-c5d2cffa08bb)