### PR TITLE
Bump `qlue-ls` version to `0.5.3`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-wasm": "^6.2.2",
-        "qlue-ls": "npm:qlue-ls-web@~0.4.0",
+        "qlue-ls": "npm:qlue-ls-web@~0.5.3",
         "rollup": "^4.26.0"
       }
     },
@@ -501,9 +501,9 @@
     },
     "node_modules/qlue-ls": {
       "name": "qlue-ls-web",
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/qlue-ls-web/-/qlue-ls-web-0.4.0.tgz",
-      "integrity": "sha512-KogeECAgw09c9SVkUJKwcKy7ys1MFVbtVa63gKghY+76FC6QM6QB14HN2Y2m5ufwWdoRkzZ8LzGglkMOTbdEzg==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/qlue-ls-web/-/qlue-ls-web-0.5.3.tgz",
+      "integrity": "sha512-+0JvvBbMs+GdADlsX5cn9ED8FIyQTBOvMUmWT3sOioKXGX7LgrFlANWRRdzf8oGg++o6f+N97/ULYmAmeMfaeg==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-wasm": "^6.2.2",
-    "qlue-ls": "npm:qlue-ls-web@~0.4.0",
+    "qlue-ls": "npm:qlue-ls-web@~0.5.3",
     "rollup": "^4.26.0"
   }
 }


### PR DESCRIPTION
In particular, this fixes the wrong formatting for `CONSTRUCT WHERE { ... }` queries.