### PR TITLE
Destroy `Treant.js` tree before re-rendering to avoid memory issues

### DIFF
--- a/backend/static/js/qleverUI.js
+++ b/backend/static/js/qleverUI.js
@@ -893,6 +893,8 @@ function showQueryPlanningTree(entry = undefined) {
   renderRuntimeInformationToDom(entry);
 }
 
+let currentTree = null;
+
 // Uses the information inside of request_log
 // to populate the DOM with the current runtime information.
 function renderRuntimeInformationToDom(entry = undefined) {
@@ -958,7 +960,11 @@ function renderRuntimeInformationToDom(entry = undefined) {
   // Draw the (new) tree, but retain the scrollbar position.
   const scrollTop = $("#visualisation").scrollTop();
   const scrollLeft = $("#result-tree").scrollLeft();
-  new Treant(treant_tree);
+  // Make sure that we are not leaking memory
+  if (currentTree !== null) {
+    currentTree.destroy();
+  }
+  currentTree = new Treant(treant_tree);
   $("#visualisation").scrollTop(scrollTop);
   $("#result-tree").scrollLeft(scrollLeft);
 


### PR DESCRIPTION
For some reason `Treant.js` does not clean itself up automatically when you overwrite a previously rendered tree. This happens frequently for the "Analysis" tree when there are live updates. This change makes sure to explicitly call `destroy()` before the tree is re-rendered.