### PR TITLE
Remove key `id` from YAML file exported by `config` command

### DIFF
--- a/backend/management/commands/config.py
+++ b/backend/management/commands/config.py
@@ -66,7 +66,13 @@ class Command(BaseCommand):
     # Get backend config and examples for the given `backend_slug`. Return the
     # result as a nicely formatted YAML string.
     def get_backend_config(self, backend_slug):
-        backend = Backend.objects.filter(slug=backend_slug).get()
+        try:
+            backend = Backend.objects.get(slug=backend_slug)
+        except Backend.DoesNotExist:
+            raise CommandError(f"Backend `{backend_slug}` does not exist")
+        except Backend.MultipleObjectsReturned:
+            # TODO: once the slug is unique this case shouldn't occur anymore
+            raise CommandError(f"Backend identifier `{backend_slug}` is not unique")
         backend_id = backend.id
 
         # Get the `Backend` config for this backend. Do not include the `id`


### PR DESCRIPTION
So far, the YAML exported or imported by the `config` command contained values for both `id` and `slug` under `backend`. Indeed, both of these are part of the `Backend` model. If the values for these differed between the YAML and the database, an error was reported. However, this made it challenging to exchange such YAML files between different users.

We now consider the `id` an implementation detail that should neither be exported nor imported. Indeed, an error is now reported if the YAML file contains an `id` key under `backend`. Only the `slug` key is used to identify the backend in the database.

NOTE: For historical reasons, the value of `slug` is not unique in the `Backend` model. It should be, but that is work for a separate PR (which will require a database migration).