### PR TITLE
Fix path for wasm

### DIFF
--- a/backend/templates/partials/head.html
+++ b/backend/templates/partials/head.html
@@ -74,7 +74,7 @@
 
   <!-- WASM formatter -->
   <script type="module">
-    import { format, determineOperationType } from "{% static '/wasm/formatter/index.js' %}";
+    import { format, determineOperationType } from "{% static 'wasm/formatter/index.js' %}";
     window.format = format;
     window.determineOperationType = determineOperationType;
   </script>


### PR DESCRIPTION
Absolute path for wasm module causes an error in production mode (debug=False).