### PR TITLE
Bump `Qlue-ls` version to 0.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@rollup/plugin-commonjs": "^28.0.1",
         "@rollup/plugin-node-resolve": "^15.3.0",
         "@rollup/plugin-wasm": "^6.2.2",
-        "qlue-ls": "npm:qlue-ls-web@~0.5.3",
+        "qlue-ls": "0.15.0",
         "rollup": "^4.26.0"
       }
     },
@@ -500,10 +500,9 @@
       }
     },
     "node_modules/qlue-ls": {
-      "name": "qlue-ls-web",
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/qlue-ls-web/-/qlue-ls-web-0.5.3.tgz",
-      "integrity": "sha512-+0JvvBbMs+GdADlsX5cn9ED8FIyQTBOvMUmWT3sOioKXGX7LgrFlANWRRdzf8oGg++o6f+N97/ULYmAmeMfaeg==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/qlue-ls/-/qlue-ls-0.15.0.tgz",
+      "integrity": "sha512-ioQin4x5Qi7uGv6bt2j6UwYBPslMJA4YVAT7HzeXoDk3rgSqwwGPVakQDGJoIeq/oMmcvfY+bNu9mFMh0V//7A==",
       "license": "SEE LICENSE IN LICENSE"
     },
     "node_modules/resolve": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@rollup/plugin-commonjs": "^28.0.1",
     "@rollup/plugin-node-resolve": "^15.3.0",
     "@rollup/plugin-wasm": "^6.2.2",
-    "qlue-ls": "npm:qlue-ls-web@~0.5.3",
+    "qlue-ls": "0.15.0",
     "rollup": "^4.26.0"
   }
 }


### PR DESCRIPTION
In particular, this fixes that a query like `INSERT DATA { <a> <b> "'." }` was not recognized as an update operation.